### PR TITLE
fix: set falcon min fee when not passed for keyreg

### DIFF
--- a/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/foundation/utils/WalletSdkExtensions.kt
+++ b/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/foundation/utils/WalletSdkExtensions.kt
@@ -3,7 +3,6 @@ package com.michaeltchuang.walletsdk.core.foundation.utils
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
-import com.ionspin.kotlin.bignum.decimal.RoundingMode
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.michaeltchuang.walletsdk.core.network.model.TransactionParams
 import kotlinx.serialization.json.Json
@@ -49,35 +48,61 @@ inline fun <reified T> NavController.getData(): T? =
         ?.savedStateHandle
         ?.getObject()
 
-val precision: Int = 3
+const val AMOUNT_FORMAT_DECIMAL_PLACES: Int = 6
 
 fun String.formatAmount(convertToMicroAmount: Boolean = true): String =
-
     try {
-        val microalgos = BigDecimal.parseString(this)
-        var divisor = BigDecimal.parseString("1")
-        if (convertToMicroAmount) {
-            divisor = BigDecimal.parseString("1000000")
-        }
-        val micros = microalgos.divide(divisor)
-
-        // Round to 6 decimal places
-        val rounded =
-            micros.roundToDigitPosition(
-                digitPosition = precision.toLong(),
-                roundingMode = RoundingMode.ROUND_HALF_AWAY_FROM_ZERO,
-            )
-
-        // Format with exactly 6 decimal places
-        val str = rounded.toStringExpanded()
-        val parts = str.split(".")
-        val intPart = parts[0]
-        val decPart = parts.getOrNull(1)?.take(precision)?.padEnd(precision, '0') ?: "000"
-
-        "$intPart.$decPart"
+        val amount = BigDecimal.parseString(this)
+        val divisor = if (convertToMicroAmount) BigDecimal.parseString(MICRO_ALGO_DIVISOR) else BigDecimal.ONE
+        amount.divide(divisor).toStringExpanded().roundDecimalString(AMOUNT_FORMAT_DECIMAL_PLACES)
     } catch (e: Exception) {
         this
     }
+
+private fun String.roundDecimalString(decimalPlaces: Int): String {
+    val parts = split(".")
+    var intPart = parts[0]
+    val decimalPart = parts.getOrNull(1).orEmpty()
+    val roundedDecimalPart = decimalPart.take(decimalPlaces).padEnd(decimalPlaces, '0').toCharArray()
+    val shouldRoundUp = decimalPart.getOrNull(decimalPlaces)?.digitToIntOrNull()?.let { it >= 5 } == true
+
+    if (shouldRoundUp) {
+        var index = roundedDecimalPart.lastIndex
+        var carry = true
+        while (index >= 0 && carry) {
+            if (roundedDecimalPart[index] == '9') {
+                roundedDecimalPart[index] = '0'
+                index--
+            } else {
+                roundedDecimalPart[index] = roundedDecimalPart[index] + 1
+                carry = false
+            }
+        }
+        if (carry) {
+            intPart = intPart.incrementDecimalIntegerString()
+        }
+    }
+
+    return "$intPart.${roundedDecimalPart.concatToString()}"
+}
+
+private fun String.incrementDecimalIntegerString(): String {
+    val digits = toCharArray()
+    var index = digits.lastIndex
+    var carry = true
+    while (index >= 0 && carry) {
+        if (digits[index] == '9') {
+            digits[index] = '0'
+            index--
+        } else {
+            digits[index] = digits[index] + 1
+            carry = false
+        }
+    }
+    return if (carry) "1${digits.concatToString()}" else digits.concatToString()
+}
+
+private const val MICRO_ALGO_DIVISOR = "1000000"
 
 expect class BytesArray
 

--- a/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/transaction/di/KeyRegTransactionModule.kt
+++ b/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/transaction/di/KeyRegTransactionModule.kt
@@ -48,6 +48,7 @@ val keyRegTransactionModule =
                 get(),
                 get(),
                 get(),
+                get(),
             )
         }
         single { GetExplorerBaseUrlUseCase() }

--- a/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/transaction/domain/usecase/CreateKeyRegTransactionUseCase.kt
+++ b/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/transaction/domain/usecase/CreateKeyRegTransactionUseCase.kt
@@ -1,6 +1,9 @@
 package com.michaeltchuang.walletsdk.core.transaction.domain.usecase
 
+import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.toBigInteger
+import com.michaeltchuang.walletsdk.core.account.domain.model.local.LocalAccount
+import com.michaeltchuang.walletsdk.core.account.domain.usecase.local.GetLocalAccount
 import com.michaeltchuang.walletsdk.core.deeplink.model.KeyRegTransactionDetail
 import com.michaeltchuang.walletsdk.core.foundation.utils.Result
 import com.michaeltchuang.walletsdk.core.foundation.utils.Result.Error
@@ -11,6 +14,7 @@ import com.michaeltchuang.walletsdk.core.network.service.getAccountRekeyAdminAdd
 import com.michaeltchuang.walletsdk.core.transaction.model.KeyRegTransaction
 import com.michaeltchuang.walletsdk.core.transaction.model.OfflineKeyRegTransactionPayload
 import com.michaeltchuang.walletsdk.core.transaction.model.OnlineKeyRegTransactionPayload
+import com.michaeltchuang.walletsdk.core.utils.MIN_FEE
 
 interface CreateKeyRegTransaction {
     suspend operator fun invoke(txnDetail: KeyRegTransactionDetail): Result<KeyRegTransaction>
@@ -21,6 +25,7 @@ internal class CreateKeyRegTransactionUseCase(
     private val buildKeyRegOfflineTransaction: BuildKeyRegOfflineTransaction,
     private val buildKeyRegOnlineTransaction: BuildKeyRegOnlineTransaction,
     private val accountApiService: AccountInformationApiService,
+    private val getLocalAccount: GetLocalAccount,
 ) : CreateKeyRegTransaction {
     override suspend fun invoke(txnDetail: KeyRegTransactionDetail): Result<KeyRegTransaction> =
         when (val params = getTransactionParams()) {
@@ -38,13 +43,13 @@ internal class CreateKeyRegTransactionUseCase(
             }
         }
 
-    private fun createTransactionByteArray(
+    private suspend fun createTransactionByteArray(
         txnDetail: KeyRegTransactionDetail,
         params: TransactionParams,
     ): ByteArray? =
         if (txnDetail.isOnlineKeyRegTxn()) {
             buildKeyRegOnlineTransaction(
-                params = txnDetail.toOnlineTxnPayload(txnDetail, params),
+                params = txnDetail.toOnlineTxnPayload(params = params, flatFee = txnDetail.getFlatFee(params)),
             )
         } else {
             buildKeyRegOfflineTransaction(
@@ -69,8 +74,8 @@ internal class CreateKeyRegTransactionUseCase(
         )
 
     private fun KeyRegTransactionDetail.toOnlineTxnPayload(
-        txnDetail: KeyRegTransactionDetail,
         params: TransactionParams,
+        flatFee: BigInteger?,
     ): OnlineKeyRegTransactionPayload =
         OnlineKeyRegTransactionPayload(
             senderAddress = address,
@@ -82,8 +87,20 @@ internal class CreateKeyRegTransactionUseCase(
             voteKeyDilution = voteKeyDilution.orEmpty(),
             txnParams = params,
             note = xnote ?: note,
-            flatFee = txnDetail.fee?.toBigInteger(),
+            flatFee = flatFee,
         )
+
+    private suspend fun KeyRegTransactionDetail.getFlatFee(params: TransactionParams): BigInteger {
+        fee?.toLongOrNull()?.takeIf { it > 0L }?.let { return it.toBigInteger() }
+
+        return if (getLocalAccount(address) is LocalAccount.Falcon24) {
+            (params.getMinimumFee() * FALCON_BUNDLE_TXN_COUNT).toBigInteger()
+        } else {
+            (params.getMinimumFee()).toBigInteger()
+        }
+    }
+
+    private fun TransactionParams.getMinimumFee(): Long = (minFee ?: MIN_FEE).coerceAtLeast(MIN_FEE)
 
     private fun KeyRegTransactionDetail.isOnlineKeyRegTxn(): Boolean =
         !voteKey.isNullOrBlank() &&
@@ -91,4 +108,8 @@ internal class CreateKeyRegTransactionUseCase(
             !voteFirstRound.isNullOrBlank() &&
             !voteLastRound.isNullOrBlank() &&
             !voteKeyDilution.isNullOrBlank()
+
+    private companion object {
+        const val FALCON_BUNDLE_TXN_COUNT = 4L
+    }
 }

--- a/wallet-sdk-core/src/commonTest/kotlin/com/michaeltchuang/walletsdk/core/foundation/utils/WalletSdkExtensionsTest.kt
+++ b/wallet-sdk-core/src/commonTest/kotlin/com/michaeltchuang/walletsdk/core/foundation/utils/WalletSdkExtensionsTest.kt
@@ -1,0 +1,34 @@
+package com.michaeltchuang.walletsdk.core.foundation.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WalletSdkExtensionsTest {
+    @Test
+    fun `EXPECT microAlgo amount formatted as Algo amount WHEN formatAmount is called`() {
+        val result = "4000".formatAmount()
+
+        assertEquals("0.004000", result)
+    }
+
+    @Test
+    fun `EXPECT amount padded to six decimals WHEN formatAmount is called`() {
+        val result = "2000000".formatAmount()
+
+        assertEquals("2.000000", result)
+    }
+
+    @Test
+    fun `EXPECT amount rounded to six decimals WHEN non micro amount has extra decimals`() {
+        val result = "0.0040005".formatAmount(convertToMicroAmount = false)
+
+        assertEquals("0.004001", result)
+    }
+
+    @Test
+    fun `EXPECT amount rounded with carry WHEN decimal rounds into integer`() {
+        val result = "0.9999995".formatAmount(convertToMicroAmount = false)
+
+        assertEquals("1.000000", result)
+    }
+}

--- a/wallet-sdk-ui/src/androidInstrumentedTest/kotlin/com/michaeltchuang/walletsdk/ui/signing/screens/KeyRegConfirmScreenshotTest.kt
+++ b/wallet-sdk-ui/src/androidInstrumentedTest/kotlin/com/michaeltchuang/walletsdk/ui/signing/screens/KeyRegConfirmScreenshotTest.kt
@@ -14,10 +14,9 @@ class KeyRegConfirmScreenshotTest(
     fun testKeyRegConfirmContent() {
         setTestContent {
             ScreenContent(
-                viewState = KeyRegConfirmViewModel.ViewState.Content,
+                viewState = KeyRegConfirmViewModel.ViewState.Content(minimumFee = "0.001"),
                 onConfirm = {},
                 onBack = {},
-                minimumFee = "0.001",
                 transactionDetail =
                     KeyRegTransactionDetail(
                         address = "AXNQ4ZE7GWQJ4HBQZ7PMJLVBQCXQJ4ZJZQM6HWQZ7PMJLVBQCXQJ4ZJZQM6H",
@@ -42,10 +41,9 @@ class KeyRegConfirmScreenshotTest(
     fun testContent() {
         setTestContent {
             ScreenContent(
-                viewState = KeyRegConfirmViewModel.ViewState.Content,
+                viewState = KeyRegConfirmViewModel.ViewState.Content(minimumFee = "0.001"),
                 onConfirm = {},
                 onBack = {},
-                minimumFee = "0.001",
                 transactionDetail =
                     KeyRegTransactionDetail(
                         address = "AXNQ4ZE7GWQJ4HBQZ7PMJLVBQCXQJ4ZJZQM6HWQZ7PMJLVBQCXQJ4ZJZQM6H",

--- a/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/signing/di/SigningModules.kt
+++ b/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/signing/di/SigningModules.kt
@@ -21,6 +21,7 @@ internal val signingModules =
                     get(),
                     get(),
                     get(),
+                    get(),
                 )
             }
 

--- a/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/signing/screens/KeyReyConfirmScreen.kt
+++ b/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/signing/screens/KeyReyConfirmScreen.kt
@@ -46,7 +46,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.michaeltchuang.walletsdk.core.deeplink.model.KeyRegTransactionDetail
-import com.michaeltchuang.walletsdk.core.foundation.utils.formatAmount
 import com.michaeltchuang.walletsdk.ui.base.designsystem.theme.AlgoKitTheme
 import com.michaeltchuang.walletsdk.ui.base.designsystem.theme.AlgoKitTheme.typography
 import com.michaeltchuang.walletsdk.ui.base.designsystem.widget.AlgoKitTopBar
@@ -66,10 +65,13 @@ fun ConfirmTransactionRequestScreen(
     showSnackBar: (message: String, isError: Boolean) -> Unit,
 ) {
     val viewState by viewModel.state.collectAsStateWithLifecycle()
-    val minimumFee by viewModel.minimumFee.collectAsStateWithLifecycle()
+    val transactionDetail = remember { viewModel.getPendingTransactionRequest() }
     val lifecycleOwner = LocalLifecycleOwner.current
     LaunchedEffect(Unit) {
         viewModel.setup(lifecycle = lifecycleOwner.lifecycle)
+    }
+    LaunchedEffect(transactionDetail) {
+        viewModel.calculateMinimumFee(transactionDetail)
     }
     LaunchedEffect(Unit) {
         viewModel.viewEvent.collect { event ->
@@ -92,8 +94,7 @@ fun ConfirmTransactionRequestScreen(
         viewState = viewState,
         onConfirm = { viewModel.confirmTransaction() },
         onBack = { navController.popBackStack() },
-        minimumFee = minimumFee,
-        transactionDetail = viewModel.getPendingTransactionRequest(),
+        transactionDetail = transactionDetail,
     )
 }
 
@@ -102,7 +103,6 @@ internal fun ScreenContent(
     viewState: KeyRegConfirmViewModel.ViewState,
     onConfirm: () -> Unit,
     onBack: () -> Unit,
-    minimumFee: String,
     transactionDetail: KeyRegTransactionDetail?,
 ) {
     when (viewState) {
@@ -110,7 +110,7 @@ internal fun ScreenContent(
             Content(
                 onConfirm = onConfirm,
                 onBack = onBack,
-                minimumFee = minimumFee,
+                viewState = viewState,
                 transactionDetail = transactionDetail,
             )
         }
@@ -125,7 +125,7 @@ internal fun ScreenContent(
 fun Content(
     onConfirm: () -> Unit,
     onBack: () -> Unit,
-    minimumFee: String,
+    viewState: KeyRegConfirmViewModel.ViewState.Content,
     transactionDetail: KeyRegTransactionDetail?,
 ) {
     Box(
@@ -141,11 +141,9 @@ fun Content(
                 onClick = onBack,
             )
             transactionDetail?.let {
-                LaunchedEffect(transactionDetail) {
-                }
                 ContentItems(
                     transactionDetail,
-                    minimumFee,
+                    viewState.minimumFee,
                 )
             }
         }
@@ -182,7 +180,7 @@ fun ContentItems(
         )
 
         // Fee
-        LabeledText(label = "Fee", value = ("\u00A6") + (txnDetail?.fee?.formatAmount() ?: minimumFee))
+        LabeledText(label = "Fee", value = ("\u00A6") + minimumFee)
 
         // Type
         LabeledText(label = "Type", value = txnDetail?.type ?: "Unknown")

--- a/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/signing/viewmodels/KeyRegConfirmViewModel.kt
+++ b/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/signing/viewmodels/KeyRegConfirmViewModel.kt
@@ -3,6 +3,8 @@ package com.michaeltchuang.walletsdk.ui.signing.viewmodels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import com.ionspin.kotlin.bignum.decimal.toBigDecimal
 import com.michaeltchuang.walletsdk.core.account.domain.model.local.LocalAccount
 import com.michaeltchuang.walletsdk.core.account.domain.usecase.local.GetLocalAccount
 import com.michaeltchuang.walletsdk.core.deeplink.model.KeyRegTransactionDetail
@@ -10,36 +12,38 @@ import com.michaeltchuang.walletsdk.core.foundation.EventDelegate
 import com.michaeltchuang.walletsdk.core.foundation.EventViewModel
 import com.michaeltchuang.walletsdk.core.foundation.StateDelegate
 import com.michaeltchuang.walletsdk.core.foundation.StateViewModel
+import com.michaeltchuang.walletsdk.core.foundation.utils.Result
+import com.michaeltchuang.walletsdk.core.foundation.utils.formatAmount
 import com.michaeltchuang.walletsdk.core.transaction.domain.usecase.CreateKeyRegTransaction
+import com.michaeltchuang.walletsdk.core.transaction.domain.usecase.GetTransactionParams
 import com.michaeltchuang.walletsdk.core.transaction.domain.usecase.SendSignedTransactionUseCase
 import com.michaeltchuang.walletsdk.core.transaction.model.KeyRegTransaction
 import com.michaeltchuang.walletsdk.core.transaction.model.SignedTransactionDetail
 import com.michaeltchuang.walletsdk.core.transaction.signmanager.ExternalTransactionSignResult
 import com.michaeltchuang.walletsdk.core.transaction.signmanager.KeyRegTransactionSignManager
 import com.michaeltchuang.walletsdk.core.transaction.signmanager.PendingTransactionRequestManger
+import com.michaeltchuang.walletsdk.core.utils.MIN_FEE
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class KeyRegConfirmViewModel(
     private val sendSignedTransactionUseCase: SendSignedTransactionUseCase,
     private val createKeyRegTransaction: CreateKeyRegTransaction,
     private val keyRegTransactionSignManager: KeyRegTransactionSignManager,
     private val getLocalAccount: GetLocalAccount,
+    private val getTransactionParams: GetTransactionParams,
     private val stateDelegate: StateDelegate<ViewState>,
     private val eventDelegate: EventDelegate<ViewEvent>,
 ) : ViewModel(),
     StateViewModel<KeyRegConfirmViewModel.ViewState> by stateDelegate,
     EventViewModel<KeyRegConfirmViewModel.ViewEvent> by eventDelegate {
-    private val _minimumFee = MutableStateFlow("0.001")
-    val minimumFee: StateFlow<String> = _minimumFee.asStateFlow()
+    private val minimumFee = MIN_FEE.toString().formatAmount()
 
     init {
-        stateDelegate.setDefaultState(ViewState.Content)
+        stateDelegate.setDefaultState(ViewState.Content(minimumFee = minimumFee))
         viewModelScope.launch {
             keyRegTransactionSignManager.keyRegTransactionSignResultFlow.collect {
                 when (it) {
@@ -98,24 +102,35 @@ class KeyRegConfirmViewModel(
     }
 
     fun calculateMinimumFee(txnDetail: KeyRegTransactionDetail?) {
-        viewModelScope.launch(Dispatchers.IO) {
-            val account = getLocalAccount.invoke(txnDetail?.address ?: return@launch)
-            val isOnlineKeyReg =
-                !txnDetail.voteKey.isNullOrEmpty() &&
-                    !txnDetail.selectionPublicKey.isNullOrEmpty() &&
-                    !txnDetail.voteFirstRound.isNullOrEmpty() &&
-                    !txnDetail.voteLastRound.isNullOrEmpty() &&
-                    !txnDetail.voteKeyDilution.isNullOrEmpty() &&
-                    !txnDetail.sprfkey.isNullOrEmpty()
-
+        viewModelScope.launch {
             val fee =
-                when {
-                    account is LocalAccount.Falcon24 && isOnlineKeyReg -> "2.003"
-                    account is LocalAccount.Falcon24 && !isOnlineKeyReg -> "0.004"
-                    isOnlineKeyReg -> "2.000"
-                    else -> "0.001"
-                }
-            _minimumFee.value = fee
+                withContext(Dispatchers.IO) {
+                    txnDetail?.fee?.toLongOrNull()?.takeIf { it > 0L }?.let {
+                        return@withContext it
+                    }
+
+                    val accountAddress = txnDetail?.address?.trim() ?: return@withContext null
+                    val account = getLocalAccount.invoke(accountAddress)
+                    val paramsResult = getTransactionParams()
+                    if (paramsResult !is Result.Success) return@withContext null
+
+                    val minimumFee = (paramsResult.data.minFee ?: MIN_FEE).coerceAtLeast(MIN_FEE)
+                    if (account is LocalAccount.Falcon24) {
+                        minimumFee * FALCON_BUNDLE_TXN_COUNT
+                    } else {
+                        minimumFee
+                    }
+                } ?: return@launch
+            updateMinimumFee(fee.toString().formatAmount())
+        }
+    }
+
+    private fun updateMinimumFee(fee: String) {
+        stateDelegate.updateState { currentState ->
+            when (currentState) {
+                is ViewState.Content -> ViewState.Content(minimumFee = fee)
+                is ViewState.Loading -> ViewState.Loading
+            }
         }
     }
 
@@ -148,17 +163,23 @@ class KeyRegConfirmViewModel(
     }
 
     private fun transactionFailed(error: String) {
-        stateDelegate.updateState { ViewState.Content }
+        stateDelegate.updateState { ViewState.Content(minimumFee = minimumFee) }
         viewModelScope.launch {
             eventDelegate.sendEvent(ViewEvent.SendSignedTransactionFailed(error))
         }
         println("confirmTransaction Failed: $error")
     }
 
+    private companion object {
+        const val FALCON_BUNDLE_TXN_COUNT = 4L
+    }
+
     sealed interface ViewState {
         data object Loading : ViewState
 
-        data object Content : ViewState
+        data class Content(
+            val minimumFee: String,
+        ) : ViewState
     }
 
     sealed interface ViewEvent {

--- a/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/signing/viewmodels/KeyRegConfirmViewModel.kt
+++ b/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/signing/viewmodels/KeyRegConfirmViewModel.kt
@@ -3,8 +3,6 @@ package com.michaeltchuang.walletsdk.ui.signing.viewmodels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.ionspin.kotlin.bignum.decimal.BigDecimal
-import com.ionspin.kotlin.bignum.decimal.toBigDecimal
 import com.michaeltchuang.walletsdk.core.account.domain.model.local.LocalAccount
 import com.michaeltchuang.walletsdk.core.account.domain.usecase.local.GetLocalAccount
 import com.michaeltchuang.walletsdk.core.deeplink.model.KeyRegTransactionDetail


### PR DESCRIPTION
## Summary
 - set falcon min fee when not passed for keyreg
 - rounding was not working for `"4000".formatAmount()` to `".004"` in kmp library we were using so changed approach

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you documented any necessary changes in the project's documentation?

## Additional Info
 - Screenshots/Recordings
