### PR TITLE
fix: don't hardcode USDC value in liquid stream

### DIFF
--- a/composeDemoApp/src/iosMain/kotlin/com/michaeltchuang/walletsdk/demo/App.ios.kt
+++ b/composeDemoApp/src/iosMain/kotlin/com/michaeltchuang/walletsdk/demo/App.ios.kt
@@ -3,6 +3,7 @@ package com.michaeltchuang.walletsdk.demo
 import androidx.compose.ui.window.ComposeUIViewController
 import com.michaeltchuang.walletsdk.core.account.domain.model.local.LocalAccount
 import com.michaeltchuang.walletsdk.core.railmpp.domain.repository.MppWalletSigner
+import com.michaeltchuang.walletsdk.core.railmpp.smartcontract.EscrowSessionVaultManagerClient
 import com.michaeltchuang.walletsdk.core.railmpp.utils.MppPayments
 import com.michaeltchuang.walletsdk.core.railmpp.utils.RailMppConstants
 import com.michaeltchuang.walletsdk.demo.di.provideViewModelModules
@@ -647,7 +648,14 @@ suspend fun settleHostVoucherOnChain(
     hostAddress: String,
     viewerAddress: String,
     viewerSignerKeyBase64: String,
+    channelIdBase64: String?,
 ) {
+    channelIdBase64
+        ?.let { runCatching { Base64.decode(it) }.getOrNull() }
+        ?.let { channelId ->
+            EscrowSessionVaultManagerClient.channelId = channelId
+            Napier.d("[HOST_SETTLE_CHANNEL_ID_CAPTURED] len=${channelId.size}")
+        }
     Napier.d("[HOST_SETTLE_START] host=$hostAddress viewer=$viewerAddress")
     val signer = buildHostMppWalletSigner(hostAddress)
     if (signer == null) {
@@ -697,13 +705,14 @@ fun registerBroadcastHandlers(
 
     // Wire the on-chain host settlement: when Android viewer sends a new voucher,
     // call settleLatestVoucher() on Algorand so lastSettled is updated.
-    iosBroadcastClaimVoucherHandler = { sessionId, viewerAddress, hostAddress, _, _, viewerPublicKeyBase64 ->
+    iosBroadcastClaimVoucherHandler = { sessionId, viewerAddress, hostAddress, _, _, viewerPublicKeyBase64, channelIdBase64 ->
         broadcastSettlementScope.launch {
-            Napier.d("[HOST_CLAIM_HANDLER] session=$sessionId viewer=$viewerAddress host=$hostAddress")
+            Napier.d("[HOST_CLAIM_HANDLER] session=$sessionId viewer=$viewerAddress host=$hostAddress channelIdPresent=${channelIdBase64 != null}")
             settleHostVoucherOnChain(
                 hostAddress = hostAddress,
                 viewerAddress = viewerAddress,
                 viewerSignerKeyBase64 = viewerPublicKeyBase64,
+                channelIdBase64 = channelIdBase64,
             )
         }
     }

--- a/wallet-sdk-core/src/androidMain/kotlin/com/michaeltchuang/walletsdk/core/railmpp/internal/MppChargeOps.android.kt
+++ b/wallet-sdk-core/src/androidMain/kotlin/com/michaeltchuang/walletsdk/core/railmpp/internal/MppChargeOps.android.kt
@@ -59,7 +59,7 @@ internal actual fun mppBuildPaymentTxn(
                 .apply { if (note != null) note(note) }
                 .build()
         } else {
-            val asaIdLong = requireNotNull(normalizedAsaId) { "asaId required for ASA transfer" }.toLong()
+            val asaIdLong = parseMppAsaId(normalizedAsaId, context = "ASA transfer")
             Transaction
                 .AssetTransferTransactionBuilder()
                 .sender(Address(sender))

--- a/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/deeplink/utils/AssetConstants.kt
+++ b/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/deeplink/utils/AssetConstants.kt
@@ -16,4 +16,11 @@ object AssetConstants {
     const val USDC_MAINNET_ID = 31566704L
     const val USDC_TESTNET_ID = 10458941L
     const val USDT_MAINNET_ID = 312769L
+
+    fun usdcIdForNetwork(network: String): Long =
+        if (network.contains("mainnet", ignoreCase = true)) {
+            USDC_MAINNET_ID
+        } else {
+            USDC_TESTNET_ID
+        }
 }

--- a/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/railmpp/MppPaymentRail.kt
+++ b/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/railmpp/MppPaymentRail.kt
@@ -1,5 +1,6 @@
 package com.michaeltchuang.walletsdk.core.railmpp
 
+import com.michaeltchuang.walletsdk.core.deeplink.utils.AssetConstants
 import com.michaeltchuang.walletsdk.core.railmpp.core.PaymentRail
 import com.michaeltchuang.walletsdk.core.railmpp.core.PaymentRailRequestParams
 import com.michaeltchuang.walletsdk.core.railmpp.core.PaymentReceipt
@@ -60,7 +61,7 @@ class MppPaymentRail(
         val isSolana = params.network.startsWith("solana:", ignoreCase = true)
 
         val asset = params.asset.trim()
-        val normalizedAsset = if (asset.equals("algo", ignoreCase = true)) ALGO_ASSET else asset
+        val normalizedAsset = normalizeAssetForNetwork(asset, params.network)
         val isAlgo = normalizedAsset.isBlank() || normalizedAsset == ALGO_ASSET
         val currency =
             if (isSolana) {
@@ -178,6 +179,17 @@ class MppPaymentRail(
             timestamp = mppNowMs(),
         )
     }
+
+    private fun normalizeAssetForNetwork(
+        asset: String,
+        network: String,
+    ): String =
+        when {
+            asset.equals("ALGO", ignoreCase = true) -> ALGO_ASSET
+            asset.equals("USDC", ignoreCase = true) ->
+                AssetConstants.usdcIdForNetwork(network).toString()
+            else -> asset
+        }
 
     private fun extractCredential(payload: Any?): String {
         if (payload is String) return payload

--- a/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/railmpp/internal/MppChargeOps.kt
+++ b/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/railmpp/internal/MppChargeOps.kt
@@ -92,6 +92,16 @@ internal fun resolveAlgodUrl(
         ?: DEFAULT_ALGOD_URLS[MppNetworks.ALGORAND_TESTNET]!!
 
 /** Decodes the 32-byte public key from a base32 Algorand address, or null if malformed. */
+internal fun parseMppAsaId(
+    asaId: String?,
+    context: String,
+): Long {
+    val normalizedAsaId = asaId?.trim()
+    require(!normalizedAsaId.isNullOrBlank()) { "asaId required for $context" }
+    return normalizedAsaId.toLongOrNull()
+        ?: throw MppVerifyException("asaId must be a numeric Algorand ASA id for $context, got '$normalizedAsaId'")
+}
+
 internal fun decodeAlgorandAddressBytes(address: String): ByteArray? {
     val cleaned = address.trim().uppercase()
     if (cleaned.length != 58) return null

--- a/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/railmpp/internal/MppProvider.kt
+++ b/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/railmpp/internal/MppProvider.kt
@@ -267,8 +267,9 @@ internal class MppProvider(
 
         val isAlgo = req.asaId == null || req.asaId == ALGO_ASSET
         val expectedAmount = BigInteger.parseString(req.amount.trim())
+        val expectedAsaId = if (isAlgo) null else parseMppAsaId(req.asaId, context = "ASA charge verification")
 
-        val resolvedPaymentIndex = resolvePaymentIndex(req, paymentIndex, decoded, isAlgo, expectedAmount)
+        val resolvedPaymentIndex = resolvePaymentIndex(req, paymentIndex, decoded, isAlgo, expectedAsaId, expectedAmount)
         val payment = decoded[resolvedPaymentIndex]
 
         // Lease is REQUIRED per spec — verify SHA-256(challengeReference) matches.
@@ -285,6 +286,7 @@ internal class MppProvider(
         providedPaymentIndex: Int,
         decoded: List<MppDecodedTxn>,
         isAlgo: Boolean,
+        expectedAsaId: Long?,
         expectedAmount: BigInteger,
     ): Int {
         // Validate the recipient address format up front (matches the original byte-decode guard).
@@ -300,7 +302,7 @@ internal class MppProvider(
                 txn.type == MppDecodedTxn.TYPE_ASSET_TRANSFER &&
                     txn.assetReceiver == req.recipient &&
                     BigInteger.fromLong(txn.assetAmount ?: 0L) == expectedAmount &&
-                    (txn.xferAsset ?: 0L) == req.asaId!!.toLong()
+                    (txn.xferAsset ?: 0L) == expectedAsaId
             }
 
         if (matchesCharge(decoded[providedPaymentIndex])) {

--- a/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/railmpp/utils/MppPayments.kt
+++ b/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/railmpp/utils/MppPayments.kt
@@ -205,6 +205,14 @@ object MppPayments {
         return isKnownVoucherIncreaseAssert && (isKnownProgramCounter || message.contains("Voucher not increasing", ignoreCase = true))
     }
 
+    fun isNothingToSettleError(message: String): Boolean {
+        val isKnownSettleAssert =
+            message.contains("opcodes=dup2", ignoreCase = true) &&
+                message.contains(">; assert", ignoreCase = true)
+        val isKnownProgramCounter = message.contains("pc=890", ignoreCase = true)
+        return isKnownSettleAssert && isKnownProgramCounter
+    }
+
     suspend fun updateVoucherOnChain(
         signer: MppWalletSigner,
         appId: Long,

--- a/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/railmpp/utils/MppPayments.kt
+++ b/wallet-sdk-core/src/commonMain/kotlin/com/michaeltchuang/walletsdk/core/railmpp/utils/MppPayments.kt
@@ -191,6 +191,20 @@ object MppPayments {
         return result
     }
 
+    fun isDuplicateVoucherUpdateError(message: String): Boolean {
+        val isKnownVoucherIncreaseAssert =
+            message.contains("Voucher not increasing", ignoreCase = true) ||
+                (
+                    message.contains("opcodes=dig 2", ignoreCase = true) &&
+                        message.contains("<; assert", ignoreCase = true)
+                )
+        val isKnownProgramCounter =
+            message.contains("pc=622", ignoreCase = true) ||
+                message.contains("pc=661", ignoreCase = true) ||
+                message.contains("pc=662", ignoreCase = true)
+        return isKnownVoucherIncreaseAssert && (isKnownProgramCounter || message.contains("Voucher not increasing", ignoreCase = true))
+    }
+
     suspend fun updateVoucherOnChain(
         signer: MppWalletSigner,
         appId: Long,
@@ -220,9 +234,7 @@ object MppPayments {
             .onSuccess { Napier.d("[VIEWER_UPDATE_VOUCHER_OK] txId=$it channelIdHash=$channelIdHash", tag = TAG) }
             .onFailure { throwable ->
                 val err = throwable.message.orEmpty()
-                val isDuplicate =
-                    err.contains("pc=622", ignoreCase = true) &&
-                        (err.contains("opcodes=dig 2", ignoreCase = true) || err.contains("Voucher not increasing", ignoreCase = true))
+                val isDuplicate = isDuplicateVoucherUpdateError(err)
                 if (isDuplicate) {
                     Napier.e(
                         "[VIEWER_UPDATE_VOUCHER_DUPLICATE_SKIP] channelIdHash=$channelIdHash reason=already_recorded_onchain",

--- a/wallet-sdk-core/src/iosMain/kotlin/com/michaeltchuang/walletsdk/core/railmpp/internal/MppChargeOps.ios.kt
+++ b/wallet-sdk-core/src/iosMain/kotlin/com/michaeltchuang/walletsdk/core/railmpp/internal/MppChargeOps.ios.kt
@@ -81,7 +81,7 @@ internal actual fun mppBuildPaymentTxn(
                 genesisID = params.genesisId,
             )
         } else {
-            val asaIdLong = requireNotNull(normalizedAsaId) { "asaId required for ASA transfer" }.toLong()
+            val asaIdLong = parseMppAsaId(normalizedAsaId, context = "ASA transfer")
             bridge.makeAssetTransferTxnWithSenderAddress(
                 senderAddress = sender,
                 receiverAddress = receiver,

--- a/wallet-sdk-ui/src/androidInstrumentedTest/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/screens/LiquidAuthOfferScreenshotTest.kt
+++ b/wallet-sdk-ui/src/androidInstrumentedTest/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/screens/LiquidAuthOfferScreenshotTest.kt
@@ -163,9 +163,6 @@ class LiquidAuthOfferScreenshotTest(
     ) {
         setTestContent {
             LiquidAuthOfferScreenContent(
-                showTopBar = true,
-                title = { Text("Liquid Auth") },
-                onBackPressed = {},
                 state = state,
                 connectionType = connectionType,
                 progressBalanceUsdc = balanceUsdc,

--- a/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/di/LiquidAuthModule.kt
+++ b/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/di/LiquidAuthModule.kt
@@ -19,6 +19,8 @@ import com.michaeltchuang.walletsdk.ui.liquidAuth.domain.usecases.ProcessBiometr
 import com.michaeltchuang.walletsdk.ui.liquidAuth.domain.usecases.RegisterPasskeyUseCase
 import com.michaeltchuang.walletsdk.ui.liquidAuth.domain.usecases.SetupMppPaymentViewerUseCase
 import com.michaeltchuang.walletsdk.ui.liquidAuth.viewmodels.AnswerViewModel
+import com.michaeltchuang.walletsdk.core.foundation.EventDelegate
+import com.michaeltchuang.walletsdk.core.foundation.StateDelegate
 import com.michaeltchuang.walletsdk.ui.settings.viewmodels.EscrowSessionVaultDebugViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.module.dsl.singleOf
@@ -61,7 +63,10 @@ val liquidAuthUIModule =
 
         viewModel {
             EscrowSessionVaultDebugViewModel(
-                get(),
+                stateDelegate = StateDelegate<EscrowSessionVaultDebugViewModel.ViewState>(),
+                eventDelegate = EventDelegate<EscrowSessionVaultDebugViewModel.ViewEvent>(),
+                mppWalletSignerUseCase = get(),
+                getLocalAccounts = get(),
             )
         }
 

--- a/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/domain/usecases/SetupMppPaymentViewerUseCase.kt
+++ b/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/domain/usecases/SetupMppPaymentViewerUseCase.kt
@@ -431,15 +431,7 @@ class SetupMppPaymentViewerUseCase(
                                             if (updateResult.isFailure) {
                                                 val firstErrText = updateResult.exceptionOrNull()?.message.orEmpty()
                                                 val duplicateVoucherUpdate =
-                                                    (
-                                                        firstErrText.contains("pc=622", ignoreCase = true) ||
-                                                            firstErrText.contains("pc=661", ignoreCase = true)
-                                                    ) &&
-                                                        (
-                                                            firstErrText.contains("opcodes=dig 2", ignoreCase = true) ||
-                                                                firstErrText.contains("Voucher not increasing", ignoreCase = true) ||
-                                                                firstErrText.contains("opcodes=dig 2; <; assert", ignoreCase = true)
-                                                        )
+                                                    MppPayments.isDuplicateVoucherUpdateError(firstErrText)
                                                 if (!duplicateVoucherUpdate) {
                                                     Log.e(
                                                         TAG,
@@ -495,15 +487,7 @@ class SetupMppPaymentViewerUseCase(
                                                 }.onFailure { err ->
                                                     val errText = err.message.orEmpty()
                                                     val duplicateVoucherUpdate =
-                                                        (
-                                                            errText.contains("pc=622", ignoreCase = true) ||
-                                                                errText.contains("pc=661", ignoreCase = true)
-                                                        ) &&
-                                                            (
-                                                                errText.contains("opcodes=dig 2", ignoreCase = true) ||
-                                                                    errText.contains("Voucher not increasing", ignoreCase = true) ||
-                                                                    errText.contains("opcodes=dig 2; <; assert", ignoreCase = true)
-                                                            )
+                                                        MppPayments.isDuplicateVoucherUpdateError(errText)
                                                     if (duplicateVoucherUpdate) {
                                                         Log.e(
                                                             TAG,
@@ -531,19 +515,11 @@ class SetupMppPaymentViewerUseCase(
                                             val onChainLatestVoucher = onChainDynamicData?.latestVoucherAmount ?: 0L
                                             val onChainLastSettled = onChainDynamicData?.lastSettled ?: 0L
                                             val duplicateVoucherUpdate =
-                                                updateResult
-                                                    .exceptionOrNull()
-                                                    ?.message
-                                                    .orEmpty()
-                                                    .let { msg ->
-                                                        msg.contains("pc=622", ignoreCase = true) &&
-                                                            (
-                                                                msg.contains("opcodes=dig 2", ignoreCase = true) ||
-                                                                    msg.contains("Voucher not increasing", ignoreCase = true)
-                                                            )
-                                                    }
-                                            val effectiveUpdateOk = updateResult.isSuccess || duplicateVoucherUpdate
+                                                MppPayments.isDuplicateVoucherUpdateError(
+                                                    updateResult.exceptionOrNull()?.message.orEmpty(),
+                                                )
                                             val caughtUp = onChainLatestVoucher >= voucherClaimed
+                                            val effectiveUpdateOk = updateResult.isSuccess || (duplicateVoucherUpdate && caughtUp)
                                             val lagMicroUsdc = (voucherClaimed - onChainLatestVoucher).coerceAtLeast(0L)
                                             Log.e(
                                                 TAG,

--- a/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/domain/usecases/SetupMppPaymentViewerUseCase.kt
+++ b/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/domain/usecases/SetupMppPaymentViewerUseCase.kt
@@ -526,36 +526,43 @@ class SetupMppPaymentViewerUseCase(
                                                 "[VIEWER_VOUCHER_CATCHUP] session=${receipt.sessionId} viewer=$receiptViewerAddress localClaimedMicroUsdc=$voucherClaimed onChainLatestVoucherMicroUsdc=$onChainLatestVoucher onChainLastSettledMicroUsdc=$onChainLastSettled caughtUp=$caughtUp lagMicroUsdc=$lagMicroUsdc updateOk=$effectiveUpdateOk duplicateSkip=$duplicateVoucherUpdate",
                                             )
 
-                                            val progressSnapshot =
-                                                safeApiCall("getSessionProgressSnapshot.postUpdate") {
-                                                    MppPayments.getSessionProgressSnapshotFromVault(
+                                            if (effectiveUpdateOk) {
+                                                val progressSnapshot =
+                                                    safeApiCall("getSessionProgressSnapshot.postUpdate") {
+                                                        MppPayments.getSessionProgressSnapshotFromVault(
+                                                            viewerAddress = receiptViewerAddress,
+                                                            hostAddress = sessionVaultHostAddress,
+                                                            appId = RailMppConstants.MPP_SESSION_VAULT_APP_ID,
+                                                            authorizedSignerPublicKey = signer.authorizedSignerPublicKey,
+                                                        )
+                                                    }
+                                                val voucherJson =
+                                                    MppPayments.createVoucherJson(
+                                                        sessionId = receipt.sessionId,
                                                         viewerAddress = receiptViewerAddress,
-                                                        hostAddress = sessionVaultHostAddress,
-                                                        appId = RailMppConstants.MPP_SESSION_VAULT_APP_ID,
-                                                        authorizedSignerPublicKey = signer.authorizedSignerPublicKey,
+                                                        viewerPublicKey = signer.authorizedSignerPublicKey,
+                                                        creatorAddress = receipt.payTo,
+                                                        blocksConsumed = blocksConsumed,
+                                                        totalAmountUsed = voucherClaimed,
+                                                        remainingMicroUsdc = progressSnapshot?.progressBalanceMicroUsdc ?: 0L,
+                                                        signatureBase64 = MppPayments.serializeVoucherSignature(voucherSignature),
                                                     )
-                                                }
-                                            val voucherJson =
-                                                MppPayments.createVoucherJson(
-                                                    sessionId = receipt.sessionId,
-                                                    viewerAddress = receiptViewerAddress,
-                                                    viewerPublicKey = signer.authorizedSignerPublicKey,
-                                                    creatorAddress = receipt.payTo,
-                                                    blocksConsumed = blocksConsumed,
-                                                    totalAmountUsed = voucherClaimed,
-                                                    remainingMicroUsdc = progressSnapshot?.progressBalanceMicroUsdc ?: 0L,
-                                                    signatureBase64 = MppPayments.serializeVoucherSignature(voucherSignature),
+                                                val signatureBase64 = MppPayments.serializeVoucherSignature(voucherSignature)
+                                                Log.e(
+                                                    TAG,
+                                                    "[SESSION_VAULT_VOUCHER_SEND] session=${receipt.sessionId} segment=${receipt.segmentIndex} claimedAmountMicroUsdc=$voucherClaimed viewer=$receiptViewerAddress host=$sessionVaultHostAddress sigLen=${voucherSignature.size}",
                                                 )
-                                            val signatureBase64 = MppPayments.serializeVoucherSignature(voucherSignature)
-                                            Log.e(
-                                                TAG,
-                                                "[SESSION_VAULT_VOUCHER_SEND] session=${receipt.sessionId} segment=${receipt.segmentIndex} claimedAmountMicroUsdc=$voucherClaimed viewer=$receiptViewerAddress host=$sessionVaultHostAddress sigLen=${voucherSignature.size}",
-                                            )
-                                            Log.e(
-                                                TAG,
-                                                "🎟️ Viewer generated voucher update: $voucherJson sig=$signatureBase64",
-                                            )
-                                            service.send(voucherJson)
+                                                Log.e(
+                                                    TAG,
+                                                    "🎟️ Viewer generated voucher update: $voucherJson sig=$signatureBase64",
+                                                )
+                                                service.send(voucherJson)
+                                            } else {
+                                                Log.e(
+                                                    TAG,
+                                                    "[SESSION_VAULT_VOUCHER_SEND_SKIP] session=${receipt.sessionId} segment=${receipt.segmentIndex} claimedAmountMicroUsdc=$voucherClaimed onChainLatestVoucherMicroUsdc=$onChainLatestVoucher lagMicroUsdc=$lagMicroUsdc reason=update_not_confirmed",
+                                                )
+                                            }
                                         }
                                     }
                                 }

--- a/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/domain/usecases/SetupMppPaymentViewerUseCase.kt
+++ b/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/domain/usecases/SetupMppPaymentViewerUseCase.kt
@@ -3,7 +3,6 @@ package com.michaeltchuang.walletsdk.ui.liquidAuth.domain.usecases
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
-import com.michaeltchuang.walletsdk.core.deeplink.utils.AssetConstants.USDC_TESTNET_ID
 import com.michaeltchuang.walletsdk.core.liquidAuth.auth.connect.SignalService
 import com.michaeltchuang.walletsdk.core.railmpp.LiquidStreamViewer
 import com.michaeltchuang.walletsdk.core.railmpp.MppClientConfig
@@ -182,7 +181,7 @@ class SetupMppPaymentViewerUseCase(
                                             budgetCap =
                                                 BudgetCap(
                                                     amount = existingOnChainBalance.toString(),
-                                                    asset = USDC_TESTNET_ID.toString(),
+                                                    asset = "USDC",
                                                 ),
                                         )
                                     }
@@ -612,7 +611,7 @@ class SetupMppPaymentViewerUseCase(
                                             ConsentTerms(
                                                 gatingMode = GatingMode.PARTIAL_TIME,
                                                 amount = MppPayments.voucherSettleWindowMicroUsdc().toString(),
-                                                asset = USDC_TESTNET_ID.toString(),
+                                                asset = "USDC",
                                                 network = mppNetwork,
                                                 payTo = sessionVaultHostAddress,
                                                 segmentDuration = 3,
@@ -684,7 +683,7 @@ class SetupMppPaymentViewerUseCase(
                                                 // then tell the server to re-issue the segment request.
                                                 liquidStreamViewer?.rtcClient?.extendBudget(
                                                     additionalMicroUsdc = depositMicroUsdc,
-                                                    asset = USDC_TESTNET_ID.toString(),
+                                                    asset = "USDC",
                                                 )
                                                 liquidStreamViewer?.rtcClient?.notifyVaultFunded(
                                                     sessionId = viewerVoucherSessionId ?: "",
@@ -745,7 +744,7 @@ class SetupMppPaymentViewerUseCase(
                                                 // then tell the server to re-issue the segment request.
                                                 liquidStreamViewer?.rtcClient?.extendBudget(
                                                     additionalMicroUsdc = depositMicroUsdc,
-                                                    asset = USDC_TESTNET_ID.toString(),
+                                                    asset = "USDC",
                                                 )
                                                 liquidStreamViewer?.rtcClient?.notifyVaultFunded(
                                                     sessionId = viewerVoucherSessionId ?: "",
@@ -826,7 +825,7 @@ class SetupMppPaymentViewerUseCase(
                                 )
                                 viewer.rtcClient.extendBudget(
                                     additionalMicroUsdc = 0L,
-                                    asset = USDC_TESTNET_ID.toString(),
+                                    asset = "USDC",
                                 )
                             }
                         }

--- a/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/screens/AnswerScreen.kt
+++ b/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/screens/AnswerScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.michaeltchuang.walletsdk.core.deeplink.utils.AssetConstants.USDC_TESTNET_ID
 import com.michaeltchuang.walletsdk.core.railmpp.core.BudgetCap
 import com.michaeltchuang.walletsdk.core.railmpp.core.ConsentApproval
 import com.michaeltchuang.walletsdk.ui.liquidAuth.state.ConnectionStatusState
@@ -214,7 +213,7 @@ fun AnswerScreen(
                                 ConsentApproval(
                                     approved = true,
                                     autoPaySegments = true,
-                                    budgetCap = BudgetCap(amount = micro.toString(), asset = USDC_TESTNET_ID.toString()),
+                                    budgetCap = BudgetCap(amount = micro.toString(), asset = "USDC"),
                                     maxAutoPaySegments = maxSegments,
                                 ),
                             )

--- a/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/service/LiquidAuthConnectionManager.kt
+++ b/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/service/LiquidAuthConnectionManager.kt
@@ -15,7 +15,6 @@ import io.github.algorandecosystem.sdk.Sdk
 import com.algorand.algosdk.transaction.SignedTransaction
 import com.algorand.algosdk.transaction.Transaction
 import com.algorand.algosdk.util.Encoder
-import com.michaeltchuang.walletsdk.core.deeplink.utils.AssetConstants.USDC_TESTNET_ID
 import com.michaeltchuang.walletsdk.core.liquidAuth.auth.connect.SignalService
 import com.michaeltchuang.walletsdk.core.railmpp.LiquidStreamCreator
 import com.michaeltchuang.walletsdk.core.railmpp.MppNetworks
@@ -86,6 +85,7 @@ class AndroidLiquidAuthConnectionManager(
     private var activePaymentSessionId: String? = null
     private var activePaymentRecipient: String? = null
     private var activePaymentAmount: String? = null
+    private var activePaymentNetwork: String? = null
     private var activeViewerAddressForVault: String? = null
     private var activeCreatorVoucherClaimSnapshot: CreatorVoucherClaimSnapshot? = null
 
@@ -193,7 +193,7 @@ class AndroidLiquidAuthConnectionManager(
                 if (isSolanaNetwork) {
                     if (network == MppNetworks.SOLANA_MAINNET) SOLANA_USDC_MAINNET_MINT else SOLANA_USDC_DEVNET_MINT
                 } else {
-                    USDC_TESTNET_ID.toString()
+                    paymentRequest.asset.takeIf { it.isNotBlank() } ?: "USDC"
                 }
             Log.d(
                 TAG,
@@ -294,6 +294,7 @@ class AndroidLiquidAuthConnectionManager(
                 activePaymentSessionId = resolvedSessionId
                 activePaymentRecipient = recipient
                 activePaymentAmount = amount
+                activePaymentNetwork = network
                 Log.e(
                     TAG,
                     "[SESSION_VAULT_BOOTSTRAP_START_BLOCK] source=creator_initialized session=$resolvedSessionId viewer=$activeViewerAddressForVault recipient=$recipient",
@@ -304,6 +305,7 @@ class AndroidLiquidAuthConnectionManager(
                 activePaymentSessionId = resolvedSessionId
                 activePaymentRecipient = recipient
                 activePaymentAmount = amount
+                activePaymentNetwork = network
                 Log.e(
                     TAG,
                     "[SESSION_VAULT_BOOTSTRAP_START_BLOCK] source=creator_reused session=$resolvedSessionId viewer=$activeViewerAddressForVault recipient=$recipient",
@@ -706,8 +708,8 @@ class AndroidLiquidAuthConnectionManager(
                         amount =
                             activePaymentAmount
                                 ?: MppPayments.voucherSettleWindowMicroUsdc().toString(),
-                        asset = USDC_TESTNET_ID.toString(),
-                        network = MppNetworks.ALGORAND_TESTNET,
+                        asset = "USDC",
+                        network = activePaymentNetwork ?: MppNetworks.ALGORAND_TESTNET,
                         payTo = activePaymentRecipient.orEmpty(),
                         segmentDuration = 3,
                         leadTime = 0,
@@ -729,6 +731,7 @@ class AndroidLiquidAuthConnectionManager(
         activePaymentSessionId = null
         activePaymentRecipient = null
         activePaymentAmount = null
+        activePaymentNetwork = null
         activeViewerAddressForVault = null
         activeCreatorVoucherClaimSnapshot = null
         activeViewerAuthorizedSignerKey = null

--- a/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/utils/LiquidStreamBlockConsumptionManager.kt
+++ b/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/utils/LiquidStreamBlockConsumptionManager.kt
@@ -398,18 +398,58 @@ internal class LiquidStreamBlockConsumptionManager(
 
                     Result.success("nothing_to_settle")
                 } else {
-                    val txId =
-                        withTimeout(CHAIN_WRITE_TIMEOUT_MS) {
-                            MppPayments
-                                .settleLatestVoucher(
-                                    signer = signer,
-                                    appId = RailMppConstants.MPP_SESSION_VAULT_APP_ID,
-                                    viewerAddress = claimSnapshot.viewerAddress,
-                                    hostAddress = creatorAddress,
-                                    authorizedSignerPublicKey = signerPublicKey,
-                                ).getOrThrow()
+                    val settleResult =
+                        try {
+                            Result.success(
+                                withTimeout(CHAIN_WRITE_TIMEOUT_MS) {
+                                    MppPayments
+                                        .settleLatestVoucher(
+                                            signer = signer,
+                                            appId = RailMppConstants.MPP_SESSION_VAULT_APP_ID,
+                                            viewerAddress = claimSnapshot.viewerAddress,
+                                            hostAddress = creatorAddress,
+                                            authorizedSignerPublicKey = signerPublicKey,
+                                        ).getOrThrow()
+                                },
+                            )
+                        } catch (ce: CancellationException) {
+                            throw ce
+                        } catch (t: Throwable) {
+                            Result.failure(t)
                         }
-                    Result.success(txId)
+
+                    if (settleResult.isSuccess) {
+                        settleResult
+                    } else {
+                        val err = settleResult.exceptionOrNull()
+                        val nothingToSettleAssert = MppPayments.isNothingToSettleError(err?.message.orEmpty())
+                        val postFailureData =
+                            if (nothingToSettleAssert) {
+                                withTimeout(CHAIN_READ_TIMEOUT_MS) {
+                                    MppPayments.getSessionDynamicDataFromVault(
+                                        viewerAddress = claimSnapshot.viewerAddress,
+                                        hostAddress = creatorAddress,
+                                        appId = RailMppConstants.MPP_SESSION_VAULT_APP_ID,
+                                        authorizedSignerPublicKey = signerPublicKey,
+                                    )
+                                }
+                            } else {
+                                null
+                            }
+                        val postFailureLatest = postFailureData?.latestVoucherAmount ?: 0L
+                        val postFailureSettled = postFailureData?.lastSettled ?: 0L
+                        val nothingLeftToSettle = postFailureLatest <= postFailureSettled
+
+                        if (nothingToSettleAssert && nothingLeftToSettle) {
+                            Log.e(
+                                tag,
+                                "[SESSION_VAULT_CLAIM_SKIP] reason=already_settled latest=$postFailureLatest settled=$postFailureSettled",
+                            )
+                            Result.success("already_settled")
+                        } else {
+                            settleResult
+                        }
+                    }
                 }
             } catch (ce: CancellationException) {
                 throw ce

--- a/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/viewmodels/AnswerViewModel.kt
+++ b/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/viewmodels/AnswerViewModel.kt
@@ -115,6 +115,7 @@ class AnswerViewModel(
     EventViewModel<AnswerViewModel.ViewEvent> by eventDelegate {
     companion object {
         private const val TAG = "AnswerViewModel"
+        private const val MIN_CBOR_REQUEST_MESSAGE_BYTES = 8
         const val NOTIFICATION_CHANNEL_ID = "NOTIFICATION_CHANNEL"
         const val SERVICE_NOTIFICATION_ID = 1000
     }
@@ -306,6 +307,14 @@ class AnswerViewModel(
                         "Incoming CBOR encoding: " +
                             if (cborBytes[0].toInt() and 0x1F == 0x1F) "INDEFINITE-LENGTH" else "DEFINITE-LENGTH",
                 )
+            }
+
+            if (cborBytes.size < MIN_CBOR_REQUEST_MESSAGE_BYTES) {
+                Napier.w(
+                    tag = TAG,
+                    message = "Ignoring non-request DataChannel payload: decodedBytes=${cborBytes.size}",
+                )
+                return
             }
 
             val message = Message(cborBytes, EncoderType.CBOR)

--- a/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/base/navigation/NavigationBottomSheet.kt
+++ b/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/base/navigation/NavigationBottomSheet.kt
@@ -111,7 +111,7 @@ enum class AlgoKitScreens {
     ADD_ASSET_SCREEN,
     SELECT_SEED_SCREEN,
     IMPORT_SEED_VAULT_ACCOUNTS_SCREEN,
-    DEVELOPER_TEST_SCREEN,
+    ESCROW_SESSION_VAULT_DEBUG_TOOL_SCREEN,
     GITHUB_REPO_SCREEN,
 }
 
@@ -739,7 +739,7 @@ fun NavigationBottomSheetNavHost(
                         onAccountsImported = onFinish,
                     )
                 }
-                composable(route = AlgoKitScreens.DEVELOPER_TEST_SCREEN.name) {
+                composable(route = AlgoKitScreens.ESCROW_SESSION_VAULT_DEBUG_TOOL_SCREEN.name) {
                     EscrowSessionVaultDebugToolScreen(navController)
                 }
                 composable(route = AlgoKitScreens.GITHUB_REPO_SCREEN.name) {

--- a/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/viewmodels/LiquidAuthOfferViewModel.kt
+++ b/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/viewmodels/LiquidAuthOfferViewModel.kt
@@ -28,7 +28,10 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -72,8 +75,15 @@ class LiquidAuthOfferViewModel(
     val currentBlockNumber: StateFlow<Long?> = _currentBlockNumber
 
     // Current network label for UI display (TESTNET/MAINNET)
-    private val _currentNetworkLabel = MutableStateFlow("TESTNET")
-    val currentNetworkLabel: StateFlow<String> = _currentNetworkLabel
+    private val _currentNetwork = MutableStateFlow(AlgorandNetwork.TESTNET)
+    val currentNetworkLabel: StateFlow<String> =
+        _currentNetwork
+            .map { network ->
+                when (network) {
+                    AlgorandNetwork.MAINNET -> "MAINNET"
+                    AlgorandNetwork.TESTNET -> "TESTNET"
+                }
+            }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "TESTNET")
 
     // Payment session ID
     private var paymentSessionId: String? = null
@@ -89,6 +99,7 @@ class LiquidAuthOfferViewModel(
     companion object {
         const val DEPOSIT_AMOUNT_MICRO_USDC = LiquidStreamConstants.DEPOSIT_AMOUNT_MICRO_USDC
         const val COST_PER_BLOCK_MICRO_USDC = LiquidStreamConstants.COST_PER_BLOCK_MICRO_USDC
+        private const val USDC_ASSET = "USDC"
     }
 
     init {
@@ -181,7 +192,7 @@ class LiquidAuthOfferViewModel(
                 sessionId = getCurrentSessionId() ?: paymentSessionId!!,
                 segmentIndex = 0,
                 amount = COST_PER_BLOCK_MICRO_USDC.toString(),
-                asset = "USDC",
+                asset = USDC_ASSET,
                 network = network,
                 payTo = creatorAddress,
                 ttl = 30,
@@ -419,7 +430,7 @@ class LiquidAuthOfferViewModel(
                 sessionId = getCurrentSessionId() ?: paymentSessionId!!,
                 segmentIndex = 0,
                 amount = COST_PER_BLOCK_MICRO_USDC.toString(),
-                asset = "USDC",
+                asset = USDC_ASSET,
                 network = network,
                 payTo = creatorAddress,
                 ttl = 30,
@@ -714,11 +725,7 @@ class LiquidAuthOfferViewModel(
     private fun observeCurrentNetwork() {
         viewModelScope.launch {
             getCurrentNetworkUseCase().collect { network ->
-                _currentNetworkLabel.value =
-                    when (network) {
-                        AlgorandNetwork.MAINNET -> "MAINNET"
-                        AlgorandNetwork.TESTNET -> "TESTNET"
-                    }
+                _currentNetwork.value = network
             }
         }
     }

--- a/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/settings/screens/DeveloperSettingsScreen.kt
+++ b/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/settings/screens/DeveloperSettingsScreen.kt
@@ -104,7 +104,7 @@ internal fun ScreenContent(
             Res.drawable.ic_session_vault_inspect,
             localizedStringResource(Res.string.escrow_session_vault_debug_tool),
         ) {
-            navController.navigate(AlgoKitScreens.DEVELOPER_TEST_SCREEN.name)
+            navController.navigate(AlgoKitScreens.ESCROW_SESSION_VAULT_DEBUG_TOOL_SCREEN.name)
         }
     }
 }

--- a/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/settings/screens/EscrowSessionVaultDebugToolScreen.kt
+++ b/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/settings/screens/EscrowSessionVaultDebugToolScreen.kt
@@ -3,6 +3,7 @@ package com.michaeltchuang.walletsdk.ui.settings.screens
 import algokit_walletsdk_kmp.wallet_sdk_ui.generated.resources.Res
 import algokit_walletsdk_kmp.wallet_sdk_ui.generated.resources.developer_settings
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,13 +19,19 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -42,12 +49,26 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun EscrowSessionVaultDebugToolScreen(navController: NavHostController) {
     val viewModel: EscrowSessionVaultDebugViewModel = koinViewModel()
-    val viewerAddress by viewModel.viewerAddress.collectAsStateWithLifecycle()
-    val creatorAddress by viewModel.creatorAddress.collectAsStateWithLifecycle()
-    val depositAmount by viewModel.depositAmountUsdc.collectAsStateWithLifecycle()
-    val remainingBalance by viewModel.remainingBalance.collectAsStateWithLifecycle()
-    val statusMessage by viewModel.statusMessage.collectAsStateWithLifecycle()
-    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val viewState by viewModel.state.collectAsStateWithLifecycle()
+    val content = viewState as EscrowSessionVaultDebugViewModel.ViewState.Content
+    var statusMessage by remember { mutableStateOf<String?>(null) }
+    val accountAddresses = content.accountAddresses
+    val viewerAddress = content.viewerAddress
+    val creatorAddress = content.creatorAddress
+    val depositAmount = content.depositAmountUsdc
+    val remainingBalance = content.remainingBalance
+    val isLoading = content.isLoading
+    val canRunVaultActions = content.canRunVaultActions
+
+    LaunchedEffect(viewModel) {
+        viewModel.viewEvent.collect { event ->
+            when (event) {
+                is EscrowSessionVaultDebugViewModel.ViewEvent.ShowStatusMessage -> {
+                    statusMessage = event.message
+                }
+            }
+        }
+    }
     val textFieldColors =
         OutlinedTextFieldDefaults.colors(
             focusedTextColor = AlgoKitTheme.colors.textMain,
@@ -91,36 +112,24 @@ fun EscrowSessionVaultDebugToolScreen(navController: NavHostController) {
             color = AlgoKitTheme.colors.textMain,
         )
 
-        OutlinedTextField(
-            value = viewerAddress,
-            onValueChange = viewModel::onViewerAddressChanged,
-            label = { Text("Viewer Address") },
-            placeholder = { Text("Algorand address of the viewer (payer)") },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-            keyboardOptions =
-                KeyboardOptions(
-                    keyboardType = KeyboardType.Ascii,
-                    imeAction = ImeAction.Next,
-                ),
+        AddressDropdownField(
+            label = "Viewer Address",
+            placeholder = "Select the viewer (payer)",
+            selectedAddress = viewerAddress,
+            accountAddresses = accountAddresses.filterNot { it == creatorAddress },
             enabled = !isLoading,
             colors = textFieldColors,
+            onAddressSelected = viewModel::onViewerAddressChanged,
         )
 
-        OutlinedTextField(
-            value = creatorAddress,
-            onValueChange = viewModel::onCreatorAddressChanged,
-            label = { Text("Creator Address") },
-            placeholder = { Text("Algorand address of the creator (payee)") },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-            keyboardOptions =
-                KeyboardOptions(
-                    keyboardType = KeyboardType.Ascii,
-                    imeAction = ImeAction.Next,
-                ),
+        AddressDropdownField(
+            label = "Creator Address",
+            placeholder = "Select the creator (payee)",
+            selectedAddress = creatorAddress,
+            accountAddresses = accountAddresses.filterNot { it == viewerAddress },
             enabled = !isLoading,
             colors = textFieldColors,
+            onAddressSelected = viewModel::onCreatorAddressChanged,
         )
 
         OutlinedTextField(
@@ -150,7 +159,7 @@ fun EscrowSessionVaultDebugToolScreen(navController: NavHostController) {
 
         Button(
             onClick = viewModel::addAmountToSessionVault,
-            enabled = !isLoading,
+            enabled = !isLoading && canRunVaultActions,
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text("Add Amount to Session Vault")
@@ -158,7 +167,7 @@ fun EscrowSessionVaultDebugToolScreen(navController: NavHostController) {
 
         Button(
             onClick = viewModel::fetchSessionVaultRemainingBalance,
-            enabled = !isLoading,
+            enabled = !isLoading && canRunVaultActions,
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text("Fetch Session Vault Balance")
@@ -166,7 +175,7 @@ fun EscrowSessionVaultDebugToolScreen(navController: NavHostController) {
 
         Button(
             onClick = viewModel::updateVoucher,
-            enabled = !isLoading,
+            enabled = !isLoading && canRunVaultActions,
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text("Update Voucher")
@@ -174,7 +183,7 @@ fun EscrowSessionVaultDebugToolScreen(navController: NavHostController) {
 
         Button(
             onClick = viewModel::verifyVoucherSignature,
-            enabled = !isLoading,
+            enabled = !isLoading && canRunVaultActions,
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text("Verify Voucher")
@@ -182,7 +191,7 @@ fun EscrowSessionVaultDebugToolScreen(navController: NavHostController) {
 
         Button(
             onClick = viewModel::settleAmount,
-            enabled = !isLoading,
+            enabled = !isLoading && canRunVaultActions,
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text("Settle Amount to Creator")
@@ -190,7 +199,7 @@ fun EscrowSessionVaultDebugToolScreen(navController: NavHostController) {
 
         Button(
             onClick = viewModel::closeSessionVault,
-            enabled = !isLoading,
+            enabled = !isLoading && canRunVaultActions,
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text("Close")
@@ -198,7 +207,7 @@ fun EscrowSessionVaultDebugToolScreen(navController: NavHostController) {
 
         Button(
             onClick = viewModel::requestCloseSessionVault,
-            enabled = !isLoading,
+            enabled = !isLoading && canRunVaultActions,
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text("Request Close")
@@ -206,7 +215,7 @@ fun EscrowSessionVaultDebugToolScreen(navController: NavHostController) {
 
         Button(
             onClick = viewModel::requestWithdraw,
-            enabled = !isLoading,
+            enabled = !isLoading && canRunVaultActions,
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text("Request Withdraw")
@@ -278,5 +287,56 @@ fun EscrowSessionVaultDebugToolScreen(navController: NavHostController) {
         }
 
         Spacer(modifier = Modifier.height(32.dp))
+    }
+}
+
+@Composable
+private fun AddressDropdownField(
+    label: String,
+    placeholder: String,
+    selectedAddress: String,
+    accountAddresses: List<String>,
+    enabled: Boolean,
+    colors: androidx.compose.material3.TextFieldColors,
+    onAddressSelected: (String) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box(modifier = Modifier.fillMaxWidth()) {
+        OutlinedTextField(
+            value = selectedAddress,
+            onValueChange = {},
+            label = { Text(label) },
+            placeholder = { Text(if (accountAddresses.isEmpty()) "No signable local accounts found" else placeholder) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            readOnly = true,
+            enabled = enabled,
+            colors = colors,
+            trailingIcon = {
+                Text(if (expanded) "▲" else "▼")
+            },
+        )
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(64.dp)
+                    .clickable(enabled = enabled && accountAddresses.isNotEmpty()) { expanded = true },
+        )
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            accountAddresses.forEach { address ->
+                DropdownMenuItem(
+                    text = { Text(address) },
+                    onClick = {
+                        onAddressSelected(address)
+                        expanded = false
+                    },
+                )
+            }
+        }
     }
 }

--- a/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/settings/viewmodels/EscrowSessionVaultDebugViewModel.kt
+++ b/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/settings/viewmodels/EscrowSessionVaultDebugViewModel.kt
@@ -2,6 +2,12 @@ package com.michaeltchuang.walletsdk.ui.settings.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.michaeltchuang.walletsdk.core.account.domain.model.local.LocalAccount
+import com.michaeltchuang.walletsdk.core.account.domain.usecase.local.GetLocalAccounts
+import com.michaeltchuang.walletsdk.core.foundation.EventDelegate
+import com.michaeltchuang.walletsdk.core.foundation.EventViewModel
+import com.michaeltchuang.walletsdk.core.foundation.StateDelegate
+import com.michaeltchuang.walletsdk.core.foundation.StateViewModel
 import com.michaeltchuang.walletsdk.core.railmpp.domain.usecase.MppWalletSignerUseCase
 import com.michaeltchuang.walletsdk.core.railmpp.smartcontract.EscrowSessionVaultManagerClient
 import com.michaeltchuang.walletsdk.core.railmpp.utils.MppPayments
@@ -10,70 +16,75 @@ import com.michaeltchuang.walletsdk.core.railmpp.utils.PaymentError
 import com.michaeltchuang.walletsdk.core.railmpp.utils.RailMppConstants
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class EscrowSessionVaultDebugViewModel(
+    private val stateDelegate: StateDelegate<ViewState>,
+    private val eventDelegate: EventDelegate<ViewEvent>,
     private val mppWalletSignerUseCase: MppWalletSignerUseCase,
-) : ViewModel() {
+    private val getLocalAccounts: GetLocalAccounts,
+) : ViewModel(),
+    StateViewModel<EscrowSessionVaultDebugViewModel.ViewState> by stateDelegate,
+    EventViewModel<EscrowSessionVaultDebugViewModel.ViewEvent> by eventDelegate {
     companion object Companion {
         private const val TAG = "EscrowSessionVaultDebugViewModel"
         private const val MICRO_USDC_MULTIPLIER = 1_000_000L
     }
 
-    private val _viewerAddress =
-        MutableStateFlow(
-            "2MFPDQMIMIYS6CCIRMNWB6IACQL6VCFRZE7STJBP4W5Q3FLHUJHIVP3FLY",
-        )
-    val viewerAddress: StateFlow<String> = _viewerAddress.asStateFlow()
-
-    private val _creatorAddress =
-        MutableStateFlow(
-            "EBRI466FDKE2LKEPUDAYTIRZZ7LLKT7YMZ7TG37II6CCOAJK44SKXY7EHI",
-        )
-    val creatorAddress: StateFlow<String> = _creatorAddress.asStateFlow()
-
-    private val _depositAmountUsdc = MutableStateFlow("0.1")
-    val depositAmountUsdc: StateFlow<String> = _depositAmountUsdc.asStateFlow()
-
-    private val _remainingBalance = MutableStateFlow<Long?>(null)
-    val remainingBalance: StateFlow<Long?> = _remainingBalance.asStateFlow()
-
-    private val _statusMessage = MutableStateFlow<String?>(null)
-    val statusMessage: StateFlow<String?> = _statusMessage.asStateFlow()
-
-    private val _isLoading = MutableStateFlow(false)
-    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+    init {
+        stateDelegate.setDefaultState(ViewState.Content())
+        loadAccountAddresses()
+    }
 
     fun onViewerAddressChanged(address: String) {
-        _viewerAddress.value = address
+        updateContent { it.copy(viewerAddress = address) }
     }
 
     fun onCreatorAddressChanged(address: String) {
-        _creatorAddress.value = address
+        updateContent { it.copy(creatorAddress = address) }
     }
 
     fun onDepositAmountChanged(amount: String) {
-        _depositAmountUsdc.value = amount
+        updateContent { it.copy(depositAmountUsdc = amount) }
+    }
+
+    private fun loadAccountAddresses() {
+        viewModelScope.launch {
+            runCatching {
+                getLocalAccounts()
+                    .filter { it is LocalAccount.HdKey || it is LocalAccount.Algo25 || it is LocalAccount.Falcon24 }
+                    .map { it.address }
+            }.onSuccess { addresses ->
+                updateContent { current ->
+                    current.copy(
+                        accountAddresses = addresses,
+                        viewerAddress = current.viewerAddress.ifBlank { addresses.getOrNull(0).orEmpty() },
+                        creatorAddress = current.creatorAddress.ifBlank { addresses.getOrNull(1).orEmpty() },
+                    )
+                }
+                if (addresses.size < 2) {
+                    sendStatus("❌ At least two signable local Algorand accounts are required.")
+                }
+            }.onFailure { err ->
+                Napier.e("[LOAD_ACCOUNTS_ERR]", err, tag = TAG)
+                sendStatus("❌ Failed to load local accounts: ${err.message.orEmpty()}")
+            }
+        }
     }
 
     fun addAmountToSessionVault() {
-        val viewer = _viewerAddress.value.trim()
-        val creator = _creatorAddress.value.trim()
-        val amountUsdc = _depositAmountUsdc.value.trim().toDoubleOrNull() ?: 1.0
+        val content = contentState()
+        val viewer = content.viewerAddress.trim()
+        val creator = content.creatorAddress.trim()
+        val amountUsdc = content.depositAmountUsdc.trim().toDoubleOrNull() ?: 1.0
         val depositMicroUsdc = (amountUsdc * MICRO_USDC_MULTIPLIER).toLong()
 
-        if (viewer.isBlank() || creator.isBlank()) {
-            _statusMessage.value = "Error: Viewer and Creator addresses are required."
-            return
-        }
+        if (!validateViewerAndCreator(content)) return
 
         viewModelScope.launch {
-            _isLoading.value = true
-            _statusMessage.value = "Depositing $amountUsdc USDC to Session Vault…"
+            setLoading(true)
+            sendStatus("Depositing $amountUsdc USDC to Session Vault…")
             try {
                 val signer = mppWalletSignerUseCase(viewer)
                 if (signer != null) {
@@ -88,8 +99,7 @@ class EscrowSessionVaultDebugViewModel(
                         }
                     result
                         .onSuccess { txId ->
-                            _statusMessage.value =
-                                "✅ Deposited $amountUsdc USDC to Session Vault!\nTxId: $txId"
+                            sendStatus("✅ Deposited $amountUsdc USDC to Session Vault!\nTxId: $txId")
                             Napier.d("[ADD_TO_VAULT_OK] txId=$txId", tag = TAG)
                         }.onFailure { err ->
                             showError(PaymentError.Companion.from(err), "ADD_TO_VAULT_ERR", err)
@@ -100,23 +110,21 @@ class EscrowSessionVaultDebugViewModel(
             } catch (e: Exception) {
                 showError(PaymentError.Companion.from(e), "ADD_TO_VAULT_EXCEPTION", e)
             } finally {
-                _isLoading.value = false
+                setLoading(false)
             }
         }
     }
 
     fun fetchSessionVaultRemainingBalance() {
-        val viewer = _viewerAddress.value.trim()
-        val creator = _creatorAddress.value.trim()
+        val content = contentState()
+        val viewer = content.viewerAddress.trim()
+        val creator = content.creatorAddress.trim()
 
-        if (viewer.isBlank() || creator.isBlank()) {
-            _statusMessage.value = "Error: Viewer and Creator addresses are required."
-            return
-        }
+        if (!validateViewerAndCreator(content)) return
 
         viewModelScope.launch {
-            _isLoading.value = true
-            _statusMessage.value = "Fetching Session Vault balance…"
+            setLoading(true)
+            sendStatus("Fetching Session Vault balance…")
             try {
                 val remaining =
                     withContext(Dispatchers.Default) {
@@ -127,33 +135,31 @@ class EscrowSessionVaultDebugViewModel(
                             algodUrl = null,
                         )
                     }
-                _remainingBalance.value = remaining
+                updateContent { it.copy(remainingBalance = remaining) }
                 val usdc = remaining / MICRO_USDC_MULTIPLIER.toDouble()
-                _statusMessage.value = "✅ Remaining balance: $usdc USDC\n($remaining microUSDC)"
+                sendStatus("✅ Remaining balance: $usdc USDC\n($remaining microUSDC)")
                 Napier.d("[FETCH_BALANCE_OK] remaining=$remaining", tag = TAG)
             } catch (e: Exception) {
                 showError(PaymentError.Companion.from(e), "FETCH_BALANCE_ERR", e)
             } finally {
-                _isLoading.value = false
+                setLoading(false)
             }
         }
     }
 
     fun updateVoucher() {
-        val viewer = _viewerAddress.value.trim()
-        val creator = _creatorAddress.value.trim()
-        val amountUsdc = _depositAmountUsdc.value.trim().toDoubleOrNull() ?: 1.0
+        val content = contentState()
+        val viewer = content.viewerAddress.trim()
+        val creator = content.creatorAddress.trim()
+        val amountUsdc = content.depositAmountUsdc.trim().toDoubleOrNull() ?: 1.0
         val requestedIncrementMicroUsdc = (amountUsdc * MICRO_USDC_MULTIPLIER).toLong()
 
-        if (viewer.isBlank() || creator.isBlank()) {
-            _statusMessage.value = "Error: Viewer and Creator addresses are required."
-            return
-        }
+        if (!validateViewerAndCreator(content)) return
 
         viewModelScope.launch {
-            _isLoading.value = true
+            setLoading(true)
             try {
-                _statusMessage.value = "Preparing voucher update..."
+                sendStatus("Preparing voucher update...")
 
                 val viewerSigner =
                     mppWalletSignerUseCase(viewer) ?: run {
@@ -191,14 +197,15 @@ class EscrowSessionVaultDebugViewModel(
                 if (newCumulative > totalDeposit) {
                     val depositUsdc = totalDeposit / 1_000_000.0
                     val requestedUsdc = newCumulative / 1_000_000.0
-                    _statusMessage.value =
+                    sendStatus(
                         "❌ ${PaymentError.VoucherExceedsDeposit.userMessage}" +
-                        "\n\nDeposited: $depositUsdc USDC  |  Requested: $requestedUsdc USDC"
+                            "\n\nDeposited: $depositUsdc USDC  |  Requested: $requestedUsdc USDC",
+                    )
                     return@launch
                 }
 
                 if (newCumulative <= lastSettled) {
-                    _statusMessage.value = "❌ ${PaymentError.NothingToSettle.userMessage}"
+                    sendStatus("❌ ${PaymentError.NothingToSettle.userMessage}")
                     return@launch
                 }
                 val channelId = EscrowSessionVaultManagerClient.channelId
@@ -226,32 +233,30 @@ class EscrowSessionVaultDebugViewModel(
                     )
                 }.onSuccess { txId ->
                     Napier.d("[UPDATE_VOUCHER_OK] txId=$txId", tag = TAG)
-                    _statusMessage.value = "✅ Voucher updated!\nTxId: $txId"
+                    sendStatus("✅ Voucher updated!\nTxId: $txId")
                 }.onFailure { err ->
                     showError(PaymentError.Companion.from(err), "UPDATE_VOUCHER_ERR", err)
                 }
             } catch (e: Exception) {
                 showError(PaymentError.Companion.from(e), "UPDATE_VOUCHER_EXCEPTION", e)
             } finally {
-                _isLoading.value = false
+                setLoading(false)
             }
         }
     }
 
     fun verifyVoucherSignature() {
-        val viewer = _viewerAddress.value.trim()
-        val creator = _creatorAddress.value.trim()
-        val amountUsdc = _depositAmountUsdc.value.trim().toDoubleOrNull() ?: 1.0
+        val content = contentState()
+        val viewer = content.viewerAddress.trim()
+        val creator = content.creatorAddress.trim()
+        val amountUsdc = content.depositAmountUsdc.trim().toDoubleOrNull() ?: 1.0
         val depositMicroUsdc = (amountUsdc * MICRO_USDC_MULTIPLIER).toLong()
 
-        if (viewer.isBlank() || creator.isBlank()) {
-            _statusMessage.value = "Error: Viewer and Creator addresses are required."
-            return
-        }
+        if (!validateViewerAndCreator(content)) return
 
         viewModelScope.launch {
-            _isLoading.value = true
-            _statusMessage.value = "Verifying voucher signature…"
+            setLoading(true)
+            sendStatus("Verifying voucher signature…")
             try {
                 val viewerSigner = mppWalletSignerUseCase(viewer)
                 if (viewerSigner != null) {
@@ -279,7 +284,7 @@ class EscrowSessionVaultDebugViewModel(
                         }
                     result
                         .onSuccess {
-                            _statusMessage.value = "✅ Signature verified!"
+                            sendStatus("✅ Signature verified!")
                             Napier.d("[VERIFY_SIGNATURE_OK]", tag = TAG)
                         }.onFailure { err ->
                             showError(PaymentError.Companion.from(err), "VERIFY_SIGNATURE_ERR", err)
@@ -290,26 +295,24 @@ class EscrowSessionVaultDebugViewModel(
             } catch (e: Exception) {
                 showError(PaymentError.Companion.from(e), "VERIFY_SIGNATURE_EXCEPTION", e)
             } finally {
-                _isLoading.value = false
+                setLoading(false)
             }
         }
     }
 
     fun settleAmount() {
-        val viewer = _viewerAddress.value.trim()
-        val creator = _creatorAddress.value.trim()
-        val amountUsdc = _depositAmountUsdc.value.trim().toDoubleOrNull() ?: 1.0
+        val content = contentState()
+        val viewer = content.viewerAddress.trim()
+        val creator = content.creatorAddress.trim()
+        val amountUsdc = content.depositAmountUsdc.trim().toDoubleOrNull() ?: 1.0
         val requestedIncrementMicroUsdc = (amountUsdc * MICRO_USDC_MULTIPLIER).toLong()
 
-        if (viewer.isBlank() || creator.isBlank()) {
-            _statusMessage.value = "Error: Viewer and Creator addresses are required."
-            return
-        }
+        if (!validateViewerAndCreator(content)) return
 
         viewModelScope.launch {
-            _isLoading.value = true
+            setLoading(true)
             try {
-                _statusMessage.value = "Preparing settlement..."
+                sendStatus("Preparing settlement...")
 
                 val viewerSigner =
                     mppWalletSignerUseCase(viewer) ?: run {
@@ -344,14 +347,15 @@ class EscrowSessionVaultDebugViewModel(
                 if (newCumulative > totalDeposit) {
                     val depositUsdc = totalDeposit / 1_000_000.0
                     val requestedUsdc = newCumulative / 1_000_000.0
-                    _statusMessage.value =
+                    sendStatus(
                         "❌ ${PaymentError.VoucherExceedsDeposit.userMessage}" +
-                        "\n\nDeposited: $depositUsdc USDC  |  Requested: $requestedUsdc USDC"
+                            "\n\nDeposited: $depositUsdc USDC  |  Requested: $requestedUsdc USDC",
+                    )
                     return@launch
                 }
 
                 if (newCumulative <= lastSettled) {
-                    _statusMessage.value = "❌ ${PaymentError.NothingToSettle.userMessage}"
+                    sendStatus("❌ ${PaymentError.NothingToSettle.userMessage}")
                     return@launch
                 }
 
@@ -369,7 +373,7 @@ class EscrowSessionVaultDebugViewModel(
                 val viewerSignature = viewerSigner.signMessage(settleMessage)
                 Napier.d("[SIGNATURE_CREATED] sigLen=${viewerSignature.size}", tag = TAG)
 
-                _statusMessage.value = "Recording voucher on-chain…"
+                sendStatus("Recording voucher on-chain…")
                 val updateTxId =
                     withContext(Dispatchers.Default) {
                         MppPayments.updateVoucherOnChain(
@@ -392,7 +396,7 @@ class EscrowSessionVaultDebugViewModel(
                         return@launch
                     }
 
-                _statusMessage.value = "Settling to creator…"
+                sendStatus("Settling to creator…")
                 val settleResult =
                     withContext(Dispatchers.Default) {
                         MppPayments.settleLatestVoucher(
@@ -407,7 +411,7 @@ class EscrowSessionVaultDebugViewModel(
 
                 settleResult
                     .onSuccess { txId ->
-                        _statusMessage.value = "✅ Settlement successful\n\nTxId:\n$txId"
+                        sendStatus("✅ Settlement successful\n\nTxId:\n$txId")
                         Napier.d("[SETTLE_OK] txId=$txId", tag = TAG)
                     }.onFailure { err ->
                         showError(PaymentError.Companion.from(err), "SETTLE_ERR", err)
@@ -415,17 +419,17 @@ class EscrowSessionVaultDebugViewModel(
             } catch (e: Exception) {
                 showError(PaymentError.Companion.from(e), "SETTLE_EXCEPTION", e)
             } finally {
-                _isLoading.value = false
+                setLoading(false)
             }
         }
     }
 
     fun closeSessionVault() {
-        val creator = _creatorAddress.value.trim()
+        val creator = contentState().creatorAddress.trim()
 
         viewModelScope.launch {
-            _isLoading.value = true
-            _statusMessage.value = "Closing session vault…"
+            setLoading(true)
+            sendStatus("Closing session vault…")
             try {
                 val creatorSigner =
                     mppWalletSignerUseCase(creator) ?: run {
@@ -453,7 +457,7 @@ class EscrowSessionVaultDebugViewModel(
 
                 result
                     .onSuccess { txId ->
-                        _statusMessage.value = "✅ Session vault closed\n\nTxId:\n$txId"
+                        sendStatus("✅ Session vault closed\n\nTxId:\n$txId")
                         Napier.d("[CLOSE_OK] txId=$txId", tag = TAG)
                     }.onFailure { err ->
                         showError(PaymentError.Companion.from(err), "CLOSE_ERR", err)
@@ -461,17 +465,17 @@ class EscrowSessionVaultDebugViewModel(
             } catch (e: Exception) {
                 showError(PaymentError.Companion.from(e), "CLOSE_EXCEPTION", e)
             } finally {
-                _isLoading.value = false
+                setLoading(false)
             }
         }
     }
 
     fun requestCloseSessionVault() {
-        val viewer = _viewerAddress.value.trim()
+        val viewer = contentState().viewerAddress.trim()
 
         viewModelScope.launch {
-            _isLoading.value = true
-            _statusMessage.value = "Requesting close of Session Vault…"
+            setLoading(true)
+            sendStatus("Requesting close of Session Vault…")
             try {
                 val viewerSigner =
                     mppWalletSignerUseCase(viewer) ?: run {
@@ -502,8 +506,7 @@ class EscrowSessionVaultDebugViewModel(
 
                 result
                     .onSuccess { txId ->
-                        _statusMessage.value =
-                            "✅ Requested for close of Session Vault\n\nTxId:\n$txId"
+                        sendStatus("✅ Requested for close of Session Vault\n\nTxId:\n$txId")
                         Napier.d("[REQUEST_CLOSE_OK] txId=$txId", tag = TAG)
                     }.onFailure { err ->
                         showError(PaymentError.Companion.from(err), "REQUEST_CLOSE_ERR", err)
@@ -511,17 +514,17 @@ class EscrowSessionVaultDebugViewModel(
             } catch (e: Exception) {
                 showError(PaymentError.Companion.from(e), "REQUEST_CLOSE_EXCEPTION", e)
             } finally {
-                _isLoading.value = false
+                setLoading(false)
             }
         }
     }
 
     fun requestWithdraw() {
-        val viewer = _viewerAddress.value.trim()
+        val viewer = contentState().viewerAddress.trim()
 
         viewModelScope.launch {
-            _isLoading.value = true
-            _statusMessage.value = "Requesting withdraw from Session Vault…"
+            setLoading(true)
+            sendStatus("Requesting withdraw from Session Vault…")
             try {
                 val viewerSigner =
                     mppWalletSignerUseCase(viewer) ?: run {
@@ -552,20 +555,18 @@ class EscrowSessionVaultDebugViewModel(
 
                 result
                     .onSuccess { txId ->
-                        _statusMessage.value =
-                            "✅ Requested withdraw from Session Vault\n\nTxId:\n$txId"
+                        sendStatus("✅ Requested withdraw from Session Vault\n\nTxId:\n$txId")
                         Napier.d("[REQUEST_WITHDRAW_OK] txId=$txId", tag = TAG)
                     }.onFailure { err ->
                         val parsed = PaymentError.Companion.from(err)
-                        // withdraw() is the payer's forced-close path. It only succeeds once
-                        // `requestClose` has been called AND the 15-minute grace period has
                         if (parsed is PaymentError.BroadcastFailed || parsed is PaymentError.Unknown) {
-                            _statusMessage.value =
+                            sendStatus(
                                 "❌ Withdraw was rejected by the contract.\n\n" +
-                                "Withdraw is the viewer's forced-close path. Make sure you:\n" +
-                                "1. Tapped 'Request Close' first (the viewer must be the payer).\n" +
-                                "2. Waited for the ~15-minute close grace period to elapse.\n\n" +
-                                "Then try 'Request Withdraw' again."
+                                    "Withdraw is the viewer's forced-close path. Make sure you:\n" +
+                                    "1. Tapped 'Request Close' first (the viewer must be the payer).\n" +
+                                    "2. Waited for the ~15-minute close grace period to elapse.\n\n" +
+                                    "Then try 'Request Withdraw' again.",
+                            )
                             Napier.e(
                                 "[REQUEST_WITHDRAW_ERR] ${parsed::class.simpleName}",
                                 err,
@@ -578,9 +579,25 @@ class EscrowSessionVaultDebugViewModel(
             } catch (e: Exception) {
                 showError(PaymentError.Companion.from(e), "REQUEST_WITHDRAW_EXCEPTION", e)
             } finally {
-                _isLoading.value = false
+                setLoading(false)
             }
         }
+    }
+
+    private fun validateViewerAndCreator(content: ViewState.Content): Boolean {
+        val viewer = content.viewerAddress.trim()
+        val creator = content.creatorAddress.trim()
+        val errorMessage =
+            when {
+                content.accountAddresses.size < 2 -> "❌ At least two signable local Algorand accounts are required."
+                viewer.isBlank() || creator.isBlank() -> "❌ Viewer and Creator addresses are required."
+                viewer == creator -> "❌ Viewer and Creator addresses must be different accounts."
+                else -> null
+            }
+        if (errorMessage != null) {
+            sendStatus(errorMessage)
+        }
+        return errorMessage == null
     }
 
     private fun showError(
@@ -588,11 +605,49 @@ class EscrowSessionVaultDebugViewModel(
         logTag: String,
         cause: Throwable? = null,
     ) {
-        _statusMessage.value = "❌ ${error.userMessage}"
+        sendStatus("❌ ${error.userMessage}")
         Napier.e(
             "[$logTag] ${error::class.simpleName}",
             cause ?: Throwable(error.userMessage),
             tag = TAG,
         )
+    }
+
+    private fun contentState(): ViewState.Content = state.value as ViewState.Content
+
+    private fun updateContent(block: (ViewState.Content) -> ViewState.Content) {
+        stateDelegate.updateState { current -> block(current as ViewState.Content) }
+    }
+
+    private fun setLoading(isLoading: Boolean) {
+        updateContent { it.copy(isLoading = isLoading) }
+    }
+
+    private fun sendStatus(message: String) {
+        eventDelegate.sendEvent(viewModelScope, ViewEvent.ShowStatusMessage(message))
+    }
+
+    sealed interface ViewState {
+        data class Content(
+            val accountAddresses: List<String> = emptyList(),
+            val viewerAddress: String = "",
+            val creatorAddress: String = "",
+            val depositAmountUsdc: String = "0.1",
+            val remainingBalance: Long? = null,
+            val isLoading: Boolean = false,
+        ) : ViewState {
+            val canRunVaultActions: Boolean
+                get() =
+                    accountAddresses.size >= 2 &&
+                        viewerAddress.isNotBlank() &&
+                        creatorAddress.isNotBlank() &&
+                        viewerAddress != creatorAddress
+        }
+    }
+
+    sealed interface ViewEvent {
+        data class ShowStatusMessage(
+            val message: String,
+        ) : ViewEvent
     }
 }

--- a/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/base/di/UiPlatformModule.ios.kt
+++ b/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/base/di/UiPlatformModule.ios.kt
@@ -1,5 +1,7 @@
 package com.michaeltchuang.walletsdk.ui.base.di
 
+import com.michaeltchuang.walletsdk.core.foundation.EventDelegate
+import com.michaeltchuang.walletsdk.core.foundation.StateDelegate
 import com.michaeltchuang.walletsdk.ui.liquidStream.IosViewerPaymentOrchestrator
 import com.michaeltchuang.walletsdk.ui.settings.viewmodels.EscrowSessionVaultDebugViewModel
 import org.koin.core.module.Module
@@ -11,7 +13,10 @@ actual fun uiPlatformModule(): Module =
     module {
         viewModel {
             EscrowSessionVaultDebugViewModel(
+                stateDelegate = StateDelegate<EscrowSessionVaultDebugViewModel.ViewState>(),
+                eventDelegate = EventDelegate<EscrowSessionVaultDebugViewModel.ViewEvent>(),
                 mppWalletSignerUseCase = get(),
+                getLocalAccounts = get(),
             )
         }
         singleOf(::IosViewerPaymentOrchestrator)

--- a/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/service/LiquidAuthConnectionManager.kt
+++ b/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/service/LiquidAuthConnectionManager.kt
@@ -8,6 +8,7 @@ import com.michaeltchuang.walletsdk.core.railmpp.core.PaymentRequest
 import com.michaeltchuang.walletsdk.core.railmpp.core.ServerConfig
 import com.michaeltchuang.walletsdk.core.railmpp.data.repository.IosSessionVaultBalanceRepository
 import com.michaeltchuang.walletsdk.core.railmpp.domain.usecase.GetRemainingSessionVaultBalanceUseCase
+import com.michaeltchuang.walletsdk.core.railmpp.smartcontract.EscrowSessionVaultManagerClient
 import com.michaeltchuang.walletsdk.core.railmpp.utils.RailMppConstants
 import com.michaeltchuang.walletsdk.ui.liquidAuth.viewmodels.LiquidAuthOfferViewModel
 import com.michaeltchuang.walletsdk.ui.liquidStream.IOSLiquidStreamCreator
@@ -50,6 +51,7 @@ var iosBroadcastClaimVoucherHandler: (
         claimedMicroUsdc: Long,
         signatureBase64: String,
         viewerPublicKeyBase64: String,
+        channelIdBase64: String?,
     ) -> Unit
 )? = null
 
@@ -490,6 +492,13 @@ class IOSLiquidAuthConnectionManager : LiquidAuthConnectionManager {
                 val voucherSessionId = msg.jsonOptString("id")
                 val voucherViewer = msg.jsonOptString("viewer")
                 val voucherViewerPublicKey = msg.jsonOptString("viewerPublicKey")
+                val voucherChannelId = msg.jsonOptString("channelId")
+                voucherChannelId
+                    ?.let(::decodeBase64OrNull)
+                    ?.let { decodedChannelId ->
+                        EscrowSessionVaultManagerClient.channelId = decodedChannelId
+                        println("$TAG: [VOUCHER_CHANNEL_ID_CAPTURED] len=${decodedChannelId.size}")
+                    }
 
                 if (signature == null ||
                     claimedAmount == null ||
@@ -564,6 +573,7 @@ class IOSLiquidAuthConnectionManager : LiquidAuthConnectionManager {
                                             claimedAmount,
                                             signature,
                                             voucherViewerPublicKey,
+                                            voucherChannelId,
                                         )
                                     }.onFailure { e ->
                                         println("$TAG: [VOUCHER_CLAIM_ERROR] $e")

--- a/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/service/LiquidAuthConnectionManager.kt
+++ b/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/service/LiquidAuthConnectionManager.kt
@@ -450,12 +450,13 @@ class IOSLiquidAuthConnectionManager : LiquidAuthConnectionManager {
                             "keyLen=${signerKey.size} session=$activePaymentSessionId",
                     )
                     // Update the server's config with the viewer's key so skipPaymentRequestWhenSessionFunded works.
+                    val fallbackNetwork = activeGatingConfig?.network ?: MppNetworks.ALGORAND_TESTNET
                     val currentGating =
                         activeGatingConfig ?: GatingConfig(
                             mode = GatingMode.PARTIAL_TIME,
                             amount = activePaymentAmount ?: "0",
                             asset = "USDC",
-                            network = MppNetworks.ALGORAND_TESTNET,
+                            network = fallbackNetwork,
                             payTo = activePaymentRecipient ?: "",
                         )
                     streamCreator?.updateConfig(

--- a/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidStream/IosLiquidStreamViewerConnectionManager.kt
+++ b/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidStream/IosLiquidStreamViewerConnectionManager.kt
@@ -1,6 +1,5 @@
 package com.michaeltchuang.walletsdk.ui.liquidStream
 
-import com.michaeltchuang.walletsdk.core.deeplink.utils.AssetConstants.USDC_TESTNET_ID
 import com.michaeltchuang.walletsdk.core.railmpp.MppClientConfig
 import com.michaeltchuang.walletsdk.core.railmpp.core.BudgetCap
 import com.michaeltchuang.walletsdk.core.railmpp.core.ClientConfig
@@ -338,7 +337,7 @@ class IosLiquidStreamViewerConnectionManager {
                                 budgetCap =
                                     BudgetCap(
                                         amount = existing.toString(),
-                                        asset = USDC_TESTNET_ID.toString(),
+                                        asset = "USDC",
                                     ),
                             )
                         }
@@ -483,7 +482,7 @@ class IosLiquidStreamViewerConnectionManager {
                     budgetCap =
                         BudgetCap(
                             amount = microUsdc.toString(),
-                            asset = USDC_TESTNET_ID.toString(),
+                            asset = "USDC",
                         ),
                     maxAutoPaySegments = maxSegments,
                 ),
@@ -521,7 +520,7 @@ class IosLiquidStreamViewerConnectionManager {
                         budgetCap =
                             BudgetCap(
                                 amount = microUsdc.toString(),
-                                asset = USDC_TESTNET_ID.toString(),
+                                asset = "USDC",
                             ),
                         maxAutoPaySegments = maxSegments,
                     ),
@@ -541,7 +540,7 @@ class IosLiquidStreamViewerConnectionManager {
                     budgetCap =
                         BudgetCap(
                             amount = microUsdc.toString(),
-                            asset = USDC_TESTNET_ID.toString(),
+                            asset = "USDC",
                         ),
                     maxAutoPaySegments = maxSegments,
                 ),
@@ -695,7 +694,7 @@ class IosLiquidStreamViewerConnectionManager {
                 }
             val amount = message.jsonOptString("amount") ?: ""
             val payTo = message.jsonOptString("payTo") ?: ""
-            val asset = message.jsonOptString("asset") ?: USDC_TESTNET_ID.toString()
+            val asset = message.jsonOptString("asset") ?: "USDC"
 
             println(
                 "$TAG: 💰 PAYMENT_REQUEST_PARSE session=$sessionId amount=$amount payTo=$payTo " +
@@ -747,7 +746,7 @@ class IosLiquidStreamViewerConnectionManager {
                                 budgetCap =
                                     BudgetCap(
                                         amount = existing.toString(),
-                                        asset = USDC_TESTNET_ID.toString(),
+                                        asset = "USDC",
                                     ),
                             ),
                         )

--- a/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidStream/IosViewerPaymentOrchestrator.kt
+++ b/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidStream/IosViewerPaymentOrchestrator.kt
@@ -134,19 +134,6 @@ class IosViewerPaymentOrchestrator(
                     tag = TAG,
                 )
 
-                // Build and send a voucher to the host so it can settle on-chain and
-                // transition from WaitingForPayment → Streaming state.
-                trySendVoucher(
-                    signer = signer,
-                    viewerAddress = viewerAddress,
-                    hostAddress = hostAddress,
-                    sessionId = sessionId,
-                    totalAmountClaimedMicroUsdc = depositMicroUsdc,
-                    segmentDebitMicroUsdc = depositMicroUsdc, // deposit voucher: full amount is the debit
-                    remainingMicroUsdc = remaining,
-                    sendMessageFn = sendMessageFn,
-                )
-
                 onResult(remaining)
             } catch (e: Exception) {
                 Napier.e("[VIEWER_DEPOSIT_EXCEPTION] viewer=$viewerAddress", e, tag = TAG)

--- a/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidStream/IosViewerPaymentOrchestrator.kt
+++ b/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidStream/IosViewerPaymentOrchestrator.kt
@@ -277,46 +277,73 @@ class IosViewerPaymentOrchestrator(
                         }
                     }.getOrNull()
 
-            if (updateTxId != null) {
-                val confirmed =
+            val txConfirmed =
+                if (updateTxId != null) {
                     withContext(Dispatchers.Default) {
                         MppPayments.awaitTransactionConfirmation(
                             txId = updateTxId,
                             algodUrl = MppPayments.TESTNET_ALGOD_URL,
                         )
+                    }.also { confirmed ->
+                        if (confirmed) {
+                            Napier.d(
+                                "[VIEWER_UPDATE_VOUCHER_CONFIRMED] session=$sessionId txId=$updateTxId",
+                                tag = TAG,
+                            )
+                        } else {
+                            Napier.w(
+                                "[VIEWER_UPDATE_VOUCHER_UNCONFIRMED] session=$sessionId txId=$updateTxId",
+                                tag = TAG,
+                            )
+                        }
                     }
-                if (confirmed) {
-                    Napier.d(
-                        "[VIEWER_UPDATE_VOUCHER_CONFIRMED] session=$sessionId txId=$updateTxId",
-                        tag = TAG,
-                    )
                 } else {
-                    Napier.w(
-                        "[VIEWER_UPDATE_VOUCHER_UNCONFIRMED] session=$sessionId txId=$updateTxId " +
-                            "sending DC voucher anyway (host may retry on next block)",
-                        tag = TAG,
-                    )
+                    false
                 }
-            }
 
-            val voucherJson =
-                MppPayments.createVoucherJson(
-                    sessionId = sessionId,
-                    viewerAddress = viewerAddress,
-                    viewerPublicKey = pubKey,
-                    creatorAddress = hostAddress,
-                    blocksConsumed = 1,
-                    totalAmountUsed = effectiveClaimedMicroUsdc,
-                    remainingMicroUsdc = remainingMicroUsdc,
-                    signatureBase64 = signatureBase64,
+            val onChainLatestVoucher =
+                runCatching {
+                    MppPayments
+                        .getSessionDynamicDataFromVault(
+                            viewerAddress = viewerAddress,
+                            hostAddress = hostAddress,
+                            appId = RailMppConstants.MPP_SESSION_VAULT_APP_ID,
+                            authorizedSignerPublicKey = pubKey,
+                        )?.latestVoucherAmount ?: 0L
+                }.getOrDefault(0L)
+            val duplicateVoucherUpdate =
+                MppPayments.isDuplicateVoucherUpdateError(updateResult.exceptionOrNull()?.message.orEmpty())
+            val caughtUp = onChainLatestVoucher >= effectiveClaimedMicroUsdc
+            val effectiveUpdateOk = updateResult.isSuccess || txConfirmed || (duplicateVoucherUpdate && caughtUp)
+
+            if (effectiveUpdateOk) {
+                val voucherJson =
+                    MppPayments.createVoucherJson(
+                        sessionId = sessionId,
+                        viewerAddress = viewerAddress,
+                        viewerPublicKey = pubKey,
+                        creatorAddress = hostAddress,
+                        blocksConsumed = 1,
+                        totalAmountUsed = effectiveClaimedMicroUsdc,
+                        remainingMicroUsdc = remainingMicroUsdc,
+                        signatureBase64 = signatureBase64,
+                    )
+
+                Napier.d(
+                    "[VIEWER_VOUCHER_SEND] session=$sessionId viewer=$viewerAddress " +
+                        "effectiveClaimed=$effectiveClaimedMicroUsdc sig=${signatureBase64.take(16)}...",
+                    tag = TAG,
                 )
-
-            Napier.d(
-                "[VIEWER_VOUCHER_SEND] session=$sessionId viewer=$viewerAddress " +
-                    "effectiveClaimed=$effectiveClaimedMicroUsdc sig=${signatureBase64.take(16)}...",
-                tag = TAG,
-            )
-            sendMessageFn(voucherJson)
+                sendMessageFn(voucherJson)
+            } else {
+                val lagMicroUsdc = (effectiveClaimedMicroUsdc - onChainLatestVoucher).coerceAtLeast(0L)
+                Napier.w(
+                    "[VIEWER_VOUCHER_SEND_SKIP] session=$sessionId viewer=$viewerAddress " +
+                        "effectiveClaimed=$effectiveClaimedMicroUsdc onChainLatestVoucher=$onChainLatestVoucher " +
+                        "lagMicroUsdc=$lagMicroUsdc reason=update_not_confirmed",
+                    tag = TAG,
+                )
+            }
         } catch (e: Exception) {
             Napier.e("[VIEWER_VOUCHER_ERR] viewer=$viewerAddress", e, tag = TAG)
         }

--- a/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidStream/IosViewerPaymentOrchestrator.kt
+++ b/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidStream/IosViewerPaymentOrchestrator.kt
@@ -260,12 +260,7 @@ class IosViewerPaymentOrchestrator(
                         )
                     }.onFailure { err ->
                         val errText = err.message.orEmpty()
-                        val isDuplicate =
-                            errText.contains("pc=622", ignoreCase = true) &&
-                                (
-                                    errText.contains("opcodes=dig 2", ignoreCase = true) ||
-                                        errText.contains("Voucher not increasing", ignoreCase = true)
-                                )
+                        val isDuplicate = MppPayments.isDuplicateVoucherUpdateError(errText)
                         if (isDuplicate) {
                             Napier.d(
                                 "[VIEWER_UPDATE_VOUCHER_DUPLICATE_SKIP] session=$sessionId " +


### PR DESCRIPTION
## Summary
 - don't hardcode USDC value in liquid stream
 - add address dropdown to escrow session vault debug tool screen
 - fix iOS modal issue not showing

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you documented any necessary changes in the project's documentation?

## Additional Info
 - Screenshots/Recordings
