### PR TITLE
fix: prevent liquid steam viewer screen closing while back button swipe 

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ timeline
              : ✅ Onboarding - Add Falcon25 (non-lsig) wallet account and escrow session vault flow
              : ✅ Settings - Add Fnet network support
              : 🔄 Liquid Stream - Research lowering cost of (Lsig / smart contract) session vault for Algorand
-             : 🔄 Liquid Stream - Add in chat and superchat functionality
-             : Testing - Add Debug Host Mode for Liquid Stream (with multiple viewers)
+             : 🔄 Liquid Stream - Add in chat and super-chat functionality
+             : 🔄 Testing - Add debug host mode for liquid stream (with multiple bot viewers)
              
     section Future 🔮
     2026Q4   

--- a/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/screens/AnswerScreen.kt
+++ b/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/screens/AnswerScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -20,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.michaeltchuang.walletsdk.ui.liquidAuth.state.ConnectionStatusState
 import com.michaeltchuang.walletsdk.ui.liquidAuth.viewmodels.AnswerViewModel
+import com.michaeltchuang.walletsdk.ui.liquidAuth.viewmodels.StreamHeartbeatVideoSink
 import com.michaeltchuang.walletsdk.ui.liquidStream.components.ViewerMppConsentDialog
 import com.michaeltchuang.walletsdk.ui.liquidStream.components.WebRtcVideoRenderer
 import com.michaeltchuang.walletsdk.ui.liquidStream.screens.LiquidStreamViewerScreen
@@ -90,6 +92,20 @@ fun AnswerScreen(
                 service.setOnRemoteVideoTrack { t -> remoteVideoTrack = t }
             }
             delay(300.milliseconds)
+        }
+    }
+
+    // Detect when the host stops streaming: mark the shared stream-timeout watchdog active
+    // whenever a real frame is delivered on the native remote video track. If the host stops
+    // its camera/ends the stream and frames stop arriving, the existing STREAM_TIMEOUT_MS watchdog in
+    // LiquidAuthViewerStateHolder fires onStreamTimeout -> StreamDisconnected, tearing down
+    // the viewer session automatically (handled below).
+    DisposableEffect(remoteVideoTrack) {
+        val track = remoteVideoTrack
+        val heartbeatSink = StreamHeartbeatVideoSink(onHeartbeat = { viewModel.markStreamFrameReceived() })
+        runCatching { track?.addSink(heartbeatSink) }
+        onDispose {
+            runCatching { track?.removeSink(heartbeatSink) }
         }
     }
 

--- a/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/screens/AnswerScreen.kt
+++ b/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/screens/AnswerScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -29,6 +30,7 @@ import kotlinx.coroutines.delay
 import org.koin.compose.viewmodel.koinViewModel
 import org.webrtc.EglBase
 import org.webrtc.VideoTrack
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Answer Screen for Liquid Auth Client
@@ -55,16 +57,20 @@ fun AnswerScreen(
     val viewerProgressBalanceMicroUsdc by viewModel.viewerProgressBalanceMicroUsdc.collectAsState()
     val currentBlockNumber by viewModel.currentBlockNumber.collectAsState()
     var deliveredMessageCount by remember { mutableIntStateOf(0) }
-
     val streamHostUiModeState = remember { mutableStateOf(StreamHostUiMode.Hidden) }
     val miniPlayerCameraPreviewState = remember { mutableStateOf<(@Composable () -> Unit)?>(null) }
-
-    // Native WebRTC remote track (host camera + mic) received on the viewer side.
-    // The peer connection (and its EGL context / tracks) is created asynchronously inside
-    // `service.peer()`, so poll until it becomes available instead of resolving once — otherwise
-    // we race the peerClient creation and end up with a null context/track (audio-only).
     var remoteVideoTrack by remember { mutableStateOf<VideoTrack?>(null) }
     var eglBaseContext by remember { mutableStateOf<EglBase.Context?>(null) }
+    val viewerBottomSheetState = rememberModalBottomSheetState(
+            skipPartiallyExpanded = true,
+            confirmValueChange = {it != SheetValue.Hidden },
+        )
+
+    var isViewerSheetVisible by rememberSaveable { mutableStateOf(true) }
+    val hasError = errorMessage != null
+    val isConnected = message != null && session != SESSION_LOGGED_OUT && !hasError
+    val isPasskeyAuthenticated = session == LIQUID_AUTH_SESSION
+    val shouldShowViewerSheet = isConnected && isPasskeyAuthenticated && isViewerSheetVisible
 
     LaunchedEffect(signalService) {
         val service = signalService ?: return@LaunchedEffect
@@ -83,21 +89,15 @@ fun AnswerScreen(
             if (track == null) {
                 service.setOnRemoteVideoTrack { t -> remoteVideoTrack = t }
             }
-            delay(300)
+            delay(300.milliseconds)
         }
     }
 
-    var isViewerSheetVisible by rememberSaveable { mutableStateOf(true) }
-    val hasError = errorMessage != null
-    val isConnected = message != null && session != SESSION_LOGGED_OUT && !hasError
-    val isPasskeyAuthenticated = session == LIQUID_AUTH_SESSION
-    val shouldShowViewerSheet = isConnected && isPasskeyAuthenticated && isViewerSheetVisible
-
     LaunchedEffect(viewModel) {
         viewModel.startRealtimeBlockNumberUpdates()
-        Log.d("AnswerScreen", "🎭 Starting to collect view events...")
+        Log.d("AnswerScreen", "Starting to collect view events...")
         viewModel.viewEvent.collect { event ->
-            Log.d("AnswerScreen", "🎭 View event received: ${event::class.simpleName}")
+            Log.d("AnswerScreen", "View event received: ${event::class.simpleName}")
             when (event) {
                 is AnswerViewModel.ViewEvent.StreamDisconnected -> {
                     Log.w("AnswerScreen", "Viewer stream disconnected: ${event.reason}")
@@ -120,26 +120,6 @@ fun AnswerScreen(
         }
     }
 
-    val viewerBottomSheetState =
-        rememberModalBottomSheetState(
-            skipPartiallyExpanded = true,
-        )
-
-    val viewerCameraPreview: (@Composable () -> Unit)? =
-        remoteVideoTrack?.let { track ->
-            {
-                WebRtcVideoRenderer(
-                    eglBaseContext = eglBaseContext,
-                    videoTrack = track,
-                    // The Android host's front camera capturer (WebRTC Camera2Session) bakes a
-                    // horizontal mirror into the transmitted frame. Undo it here so the viewer
-                    // sees the same (correctly oriented) footage as the host's own self-preview,
-                    // matching the equivalent fix in the iOS viewer (LiquidAuthService.swift).
-                    mirror = true,
-                )
-            }
-        }
-
     LaunchedEffect(viewModel) {
         viewModel.chatMessages.collect { messages ->
             if (messages.size > deliveredMessageCount) {
@@ -150,6 +130,17 @@ fun AnswerScreen(
             }
         }
     }
+
+    val viewerCameraPreview: (@Composable () -> Unit)? =
+        remoteVideoTrack?.let { track ->
+            {
+                WebRtcVideoRenderer(
+                    eglBaseContext = eglBaseContext,
+                    videoTrack = track,
+                    mirror = true,
+                )
+            }
+        }
 
     Box(modifier = Modifier.fillMaxSize()) {
         if (shouldShowViewerSheet) {

--- a/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/viewmodels/StreamHeartbeatVideoSink.kt
+++ b/wallet-sdk-ui/src/androidMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/viewmodels/StreamHeartbeatVideoSink.kt
@@ -1,0 +1,27 @@
+package com.michaeltchuang.walletsdk.ui.liquidAuth.viewmodels
+
+import org.webrtc.VideoFrame
+import org.webrtc.VideoSink
+
+/**
+ * A [VideoSink] that can be attached to a remote [org.webrtc.VideoTrack] purely to detect
+ * stream activity, independent of whatever sink is actually rendering the frames
+ * (e.g. `WebRtcTextureViewRenderer`). WebRTC tracks support multiple simultaneous sinks, so
+ * this can be added/removed alongside the real renderer without affecting playback.
+ *
+ * This is the only bit that has to be Android-specific, since [VideoSink]/[VideoFrame] come
+ * from the Android WebRTC library. The actual throttling behavior lives in the shared
+ * [FrameHeartbeatThrottle] so it's identical to iOS's heartbeat path.
+ */
+class StreamHeartbeatVideoSink(
+    minIntervalMs: Long = 500L,
+    private val onHeartbeat: () -> Unit,
+) : VideoSink {
+    private val throttle = FrameHeartbeatThrottle(minIntervalMs)
+
+    override fun onFrame(frame: VideoFrame) {
+        if (throttle.onSignal()) {
+            onHeartbeat()
+        }
+    }
+}

--- a/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/viewmodels/FrameHeartbeatThrottle.kt
+++ b/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/viewmodels/FrameHeartbeatThrottle.kt
@@ -1,0 +1,37 @@
+package com.michaeltchuang.walletsdk.ui.liquidAuth.viewmodels
+
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * Throttles a high-frequency "a video frame was rendered" signal down to a low-rate heartbeat.
+ *
+ * Native WebRTC renderers deliver frames at up to the source frame rate (e.g. 30-60fps), but
+ * all we need in order to keep [LiquidAuthViewerStateHolder]'s stream-timeout watchdog alive is
+ * an occasional pulse. Sharing this logic in `commonMain` (rather than duplicating it per
+ * platform) guarantees Android's native WebRTC `VideoSink` adapter (`StreamHeartbeatVideoSink`)
+ * and iOS's Swift-driven renderer callback behave identically, regardless of how often each
+ * platform actually invokes them - callers on both platforms can simply forward every frame and
+ * let this class decide when a heartbeat should actually fire.
+ */
+class FrameHeartbeatThrottle(
+    private val minIntervalMs: Long = 500L,
+) {
+    private var lastFiredAtMs = 0L
+
+    @OptIn(ExperimentalTime::class)
+    private fun nowMs(): Long = Clock.System.now().toEpochMilliseconds()
+
+    /**
+     * Call this on every frame/signal. Returns `true` at most once every [minIntervalMs] -
+     * callers should treat a `true` result as "emit the heartbeat now" and ignore `false`.
+     */
+    fun onSignal(): Boolean {
+        val now = nowMs()
+        if (now - lastFiredAtMs >= minIntervalMs) {
+            lastFiredAtMs = now
+            return true
+        }
+        return false
+    }
+}

--- a/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/viewmodels/LiquidAuthViewerStateHolder.kt
+++ b/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/viewmodels/LiquidAuthViewerStateHolder.kt
@@ -57,8 +57,10 @@ open class LiquidAuthViewerStateHolder : ViewModel() {
     companion object {
         private const val TAG = "LiquidAuthViewerState"
 
-        // 10 seconds without frames = stream ended.
-        private const val STREAM_TIMEOUT_MS = 10_000L
+        // No frames for this long = stream ended. Tune this to trade off responsiveness
+        // (lower = viewer disconnects faster after the host stops) vs. tolerance for
+        // transient frame gaps/hiccups (higher = fewer false-positive disconnects).
+        private const val STREAM_TIMEOUT_MS = 2_000L
 
         private const val BASE58_ALPHABET =
             "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
@@ -194,7 +196,7 @@ open class LiquidAuthViewerStateHolder : ViewModel() {
                     onStreamTimeout(reason)
                 }
 
-                delay(500) // Check every 500ms
+                delay(200) // Poll frequently relative to STREAM_TIMEOUT_MS for prompt detection
             }
         }
     }
@@ -279,6 +281,26 @@ open class LiquidAuthViewerStateHolder : ViewModel() {
             hasReceivedAtLeastOneFrame = true
             hasTimedOutCurrentStream = false
         }
+    }
+
+    /**
+     * Lightweight heartbeat for native WebRTC media tracks (as opposed to the legacy
+     * `liquid:video:frame` JSON-message path handled by [setVideoFrame]).
+     *
+     * Platforms that render the remote video track natively (e.g. Android's
+     * `SurfaceViewRenderer`/`VideoSink`, iOS's `RTCMTLVideoView`) have no reason to decode
+     * frame bytes just to keep the stream-timeout watchdog alive — they can call this
+     * whenever a frame is actually rendered/delivered to mark the stream as active without
+     * the overhead of allocating/storing [VideoFrameData].
+     *
+     * Once frames stop arriving (e.g. the host stops or disconnects), the existing watchdog
+     * started in the class initializer will fire [onStreamTimeout] after [STREAM_TIMEOUT_MS],
+     * tearing down the viewer connection automatically.
+     */
+    fun markStreamFrameReceived() {
+        _lastFrameTimestamp.value = currentTimeMillis()
+        hasReceivedAtLeastOneFrame = true
+        hasTimedOutCurrentStream = false
     }
 
     /** Returns whether a frame was received within the timeout window. */

--- a/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidStream/screens/LiquidStreamViewerScreen.kt
+++ b/wallet-sdk-ui/src/commonMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidStream/screens/LiquidStreamViewerScreen.kt
@@ -8,7 +8,9 @@ import algokit_walletsdk_kmp.wallet_sdk_ui.generated.resources.ic_eye
 import algokit_walletsdk_kmp.wallet_sdk_ui.generated.resources.ic_gift
 import algokit_walletsdk_kmp.wallet_sdk_ui.generated.resources.ic_minimise
 import algokit_walletsdk_kmp.wallet_sdk_ui.generated.resources.ic_send
+import algokit_walletsdk_kmp.wallet_sdk_ui.generated.resources.ic_user
 import algokit_walletsdk_kmp.wallet_sdk_ui.generated.resources.ic_wallet
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -63,6 +65,7 @@ import com.michaeltchuang.walletsdk.ui.liquidStream.components.StreamViewerTopUp
 import com.michaeltchuang.walletsdk.ui.liquidStream.viewmodels.ChatUiMessage
 import com.michaeltchuang.walletsdk.ui.liquidStream.viewmodels.LiquidAuthViewerViewModel
 import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.vectorResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
@@ -351,7 +354,13 @@ private fun Header(
                             .clip(CircleShape)
                             .border(1.dp, Color(0xFF3FD2EF), CircleShape)
                             .background(Color(0x29FFFFFF)),
-                )
+                ) {
+                    Image(
+                        painter = painterResource(Res.drawable.ic_user),
+                        contentDescription = null,
+                        modifier = Modifier.size(38.dp),
+                    )
+                }
                 Box(
                     modifier =
                         Modifier

--- a/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/service/LiquidAuthConnectionManager.ios.kt
+++ b/wallet-sdk-ui/src/iosMain/kotlin/com/michaeltchuang/walletsdk/ui/liquidAuth/service/LiquidAuthConnectionManager.ios.kt
@@ -18,6 +18,7 @@ import com.michaeltchuang.walletsdk.ui.liquidAuth.domain.model.displayName
 import com.michaeltchuang.walletsdk.ui.liquidAuth.domain.model.parseIceConnectionType
 import com.michaeltchuang.walletsdk.ui.liquidAuth.utils.LiquidStreamBlockConsumptionManager
 import com.michaeltchuang.walletsdk.ui.liquidAuth.viewmodels.AnswerViewModel
+import com.michaeltchuang.walletsdk.ui.liquidAuth.viewmodels.FrameHeartbeatThrottle
 import com.michaeltchuang.walletsdk.ui.liquidAuth.viewmodels.LiquidAuthOfferViewModel
 import com.michaeltchuang.walletsdk.ui.liquidStream.domain.transport.BroadcastRtcRtpSender
 import com.michaeltchuang.walletsdk.ui.liquidStream.domain.transport.CallbackRtcDataChannel
@@ -97,6 +98,7 @@ actual class LiquidAuthConnectionManager actual constructor(
 
     private var viewModel: LiquidAuthOfferViewModel? = null
     private var answerViewModel: AnswerViewModel? = null
+    private val viewerFrameHeartbeatThrottle = FrameHeartbeatThrottle()
     private var activeRequestId: String? = null
     private var activeViewerOrigin: String? = null
     private var activeViewerRequestId: String? = null
@@ -313,6 +315,26 @@ actual class LiquidAuthConnectionManager actual constructor(
         startViewerOnChainRefreshIfReady()
         maybeSetupViewerPaymentRail()
         answerViewModel?.openViewerPaymentRail()
+    }
+
+    /**
+     * Swift should call this whenever a frame is actually rendered on the remote video view
+     * returned by [iosViewerVideoViewProvider] (e.g. from the `RTCVideoRenderer.renderFrame`
+     * delegate callback backing that view). This keeps the shared stream-timeout watchdog in
+     * [AnswerViewModel] (via `LiquidAuthViewerStateHolder`) alive while the host is actively
+     * streaming, mirroring the Android native-track heartbeat. If the host stops streaming and
+     * frames stop arriving, the watchdog fires after `STREAM_TIMEOUT_MS` and tears the viewer
+     * down automatically.
+     *
+     * Safe to call on every single frame - [viewerFrameHeartbeatThrottle] (the same shared
+     * throttle used by Android's `StreamHeartbeatVideoSink`) downsamples it to a low-rate
+     * heartbeat, so Swift doesn't need to do its own throttling.
+     */
+    @Suppress("unused")
+    fun notifyViewerVideoFrameReceived() {
+        if (viewerFrameHeartbeatThrottle.onSignal()) {
+            answerViewModel?.markStreamFrameReceived()
+        }
     }
 
     @Suppress("unused")


### PR DESCRIPTION
## Summary
 - Prevent liquid steam viewer screen closing while back button swipe 
 - Close viewer stream after 2 secs of missed host frames
 - Add default profile picture for viewer screen

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you documented any necessary changes in the project's documentation?

## Additional Info
 - Screenshots/Recordings

https://github.com/user-attachments/assets/ae30c90a-2c51-4d02-9eaf-f3324cb74ebe

